### PR TITLE
[BUGFIX] #30 piwik: avoid mixed content for counter pixel

### DIFF
--- a/Resources/Private/Templates/PageParts/ServicePiwik.html
+++ b/Resources/Private/Templates/PageParts/ServicePiwik.html
@@ -19,4 +19,4 @@ var d=document,
 	g.src=u+'piwik.js';
 	s.parentNode.insertBefore(g,s);
 })();
-</script><noscript><p><img src="http://{piwikUrl}/piwik.php?idsite={piwikId}" style="border:0" alt="" /></p></noscript>
+</script><noscript><p><img src="//{piwikUrl}/piwik.php?idsite={piwikId}" style="border:0" alt="" /></p></noscript>


### PR DESCRIPTION
Use // instead of http:// for the piwik counter pixel. That's the way the original piwik tracking code is doing it.