### PR TITLE
added recursive field editing in Backen Page/SEO module

### DIFF
--- a/Classes/Backend/Ajax/PageAjax.php
+++ b/Classes/Backend/Ajax/PageAjax.php
@@ -619,6 +619,30 @@ class PageAjax extends \Metaseo\Metaseo\Backend\Ajax\AbstractAjax {
     }
 
     /**
+     * Update page field recursively.
+     */
+    protected function executeUpdatePageFieldRecursively()
+    {
+        if (empty($this->postVar['pid']) || empty($this->postVar['field'])
+        ) {
+            return;
+        }
+
+        $pid            = $this->postVar['pid'];
+        $sysLanguage    = (int) $this->postVar['sysLanguage'];
+        $depth          = (int)$this->postVar['depth'];
+        $fieldList      = array();
+
+        $list           = $this->listDefaultTree($page, 999, $sysLanguage, $fieldList);
+
+        foreach ($list as $key => $page) {
+            $this->postVar['pid'] = $key;
+            $this->executeUpdatePageField();
+        }
+    }
+
+
+    /**
      * Update field in page table
      *
      * @param integer      $pid         PID

--- a/Classes/Controller/BackendPageSeoController.php
+++ b/Classes/Controller/BackendPageSeoController.php
@@ -162,6 +162,7 @@ class BackendPageSeoController extends \Metaseo\Metaseo\Backend\Module\AbstractS
             'boolean_yes'                      => 'boolean.yes',
             'boolean_no'                       => 'boolean.no',
             'button_save'                      => 'button.save',
+            'button_saverecursively'           => 'button.saverecursively',
             'button_cancel'                    => 'button.cancel',
             'labelDepth'                       => 'label.depth',
             'labelSearchFulltext'              => 'label.search.fulltext',
@@ -254,3 +255,4 @@ class BackendPageSeoController extends \Metaseo\Metaseo\Backend\Module\AbstractS
         return $this->handleSubAction('pagetitlesim');
     }
 }
+

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -224,6 +224,10 @@
                 <source>Save</source>
                 <target>Speichern</target>
             </trans-unit>
+            <trans-unit id="button.saverecursively" xml:space="preserve" approved="yes">
+                <source>Save recursively</source>
+                <target>Rekursiv speichern</target>
+            </trans-unit>
             <trans-unit id="button.cancel" xml:space="preserve" approved="yes">
                 <source>Cancel</source>
                 <target>Abbrechen</target>
@@ -539,3 +543,4 @@
         </body>
     </file>
 </xliff>
+

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -169,6 +169,9 @@
             <trans-unit id="button.save" xml:space="preserve">
                 <source>Save</source>
             </trans-unit>
+            <trans-unit id="button.saverecursively" xml:space="preserve">
+                <source>Save recursively</source>
+            </trans-unit>
             <trans-unit id="button.cancel" xml:space="preserve">
                 <source>Cancel</source>
             </trans-unit>
@@ -406,3 +409,4 @@
         </body>
     </file>
 </xliff>
+

--- a/Resources/Public/Backend/JavaScript/MetaSeo.overview.js
+++ b/Resources/Public/Backend/JavaScript/MetaSeo.overview.js
@@ -285,6 +285,43 @@ MetaSeo.overview.grid = {
                         items: [field],
                         buttons: [
                             {
+                                text: MetaSeo.overview.conf.lang.button_saverecursively,
+                                itemId: 'form-button-save-recursively',
+
+                                disabled: true,
+                                handler: function(cmp, e) {
+                                    grid.loadMask.show();
+
+                                    var pid = record.get('uid');
+                                    var fieldValue = editWindow.getComponent('form-field').getValue();
+
+                                    var callbackFinish = function(response) {
+                                        var response = Ext.decode(response.responseText);
+
+                                        if( response && response.error ) {
+                                            TYPO3.Flashmessage.display(TYPO3.Severity.error, '', Ext.util.Format.htmlEncode(response.error) );
+                                        }
+
+                                        grid.getStore().load();
+                                    };
+
+                                    Ext.Ajax.request({
+                                        url: MetaSeo.overview.conf.ajaxController + '&cmd=updatePageFieldRecursively',
+                                        params: {
+                                            pid             : Ext.encode(pid),
+                                            field           : Ext.encode(fieldName),
+                                            value           : Ext.encode(fieldValue),
+                                            sysLanguage     : Ext.encode( MetaSeo.overview.conf.sysLanguage ),
+                                            mode            : Ext.encode( MetaSeo.overview.conf.listType ),
+                                            sessionToken    : Ext.encode( MetaSeo.overview.conf.sessionToken )
+                                        },
+                                        success: callbackFinish,
+                                        failure: callbackFinish
+                                    });
+                                
+                                    editWindow.destroy();
+                                }
+                            },{
                                 text: MetaSeo.overview.conf.lang.button_save,
                                 itemId: 'form-button-save',
                                 disabled: true,
@@ -332,14 +369,17 @@ MetaSeo.overview.grid = {
 
                     var formField = editWindow.getComponent('form-field');
                     var formButtonSave = editWindow.getFooterToolbar().getComponent('form-button-save');
+                    var formButtonSaveRecursively = editWindow.getFooterToolbar().getComponent('form-button-save-recursively');
 
                     // add listeners
                     formField.on('valid', function () {
                         formButtonSave.setDisabled(false);
+                        formButtonSaveRecursively.setDisabled(false);
                     });
 
                     formField.on('invalid', function () {
                         formButtonSave.setDisabled(true);
+                        formButtonSaveRecursively.setDisabled(true);
                     });
 
 
@@ -1042,3 +1082,4 @@ MetaSeo.overview.grid = {
 
 
 };
+


### PR DESCRIPTION
Hey,

I needed recursive editing of blacklisted pages (On big pagetrees this comes very handy if you don't want specific subtrees to appear in the sitemap). So I added a button to edit fields recursively to the SEO/Metatags backend-plugin.
Maybe you're interested in that feature.

Kind Regards,
Yannick
