### PR TITLE
[bugfix] Type error in GeneralUtility if rootline is not available

### DIFF
--- a/Classes/Utility/GeneralUtility.php
+++ b/Classes/Utility/GeneralUtility.php
@@ -116,7 +116,7 @@ class GeneralUtility {
             #################
             if (empty(self::$rootlineCache['__CURRENT__'])) {
                 // Current rootline
-                $rootline = $GLOBALS['TSFE']->tmpl->rootLine;
+                $rootline = (array)$GLOBALS['TSFE']->tmpl->rootLine;
 
                 // Filter rootline by siteroot
                 $rootline = self::filterRootlineBySiteroot((array)$rootline);
@@ -131,7 +131,7 @@ class GeneralUtility {
             #################
             if (empty(self::$rootlineCache[$uid])) {
                 // Fetch full rootline to TYPO3 root (0)
-                $rootline = self::getSysPageObj()->getRootLine($uid);
+                $rootline = (array)self::getSysPageObj()->getRootLine($uid);
 
                 // Filter rootline by siteroot
                 $rootline = self::filterRootlineBySiteroot((array)$rootline);


### PR DESCRIPTION
It's possible that $GLOBALS['TSFE']->tmpl->rootLine is not set, e.g. if page type was set to shortcut combined with EXT:realurl

__The following error occours:__
PHP Catchable Fatal Error: Argument 1 passed to Metaseo\Metaseo\Utility\GeneralUtility::filterRootlineBySiteroot() must be an array, null given, called in /htdocs/typo3conf/ext/metaseo/Classes/Utility/GeneralUtility.php on line 122 and defined in /htdocs/b-tu/typo3conf/ext/metaseo/Classes/Utility/GeneralUtility.php line 155 