### PR TITLE
Change wizard registration to reflect deprecation

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -87,7 +87,13 @@ $tempColumns = array(
                     'type'         => 'popup',
                     'title'        => 'Link',
                     'icon'         => 'link_popup.gif',
-                    'script'       => 'browse_links.php?mode=wizard&act=url',
+                    'module' => array(
+                        'name' => 'wizard_element_browser',
+                        'urlParameters' => array(
+                            'mode' => 'wizard',
+                            'act' => 'url'
+                        )
+                    ),
                     'params'       => array(
                         'blindLinkOptions' => 'mail',
                     ),

--- a/Configuration/TCA/Overrides/pages_language_overlay.php
+++ b/Configuration/TCA/Overrides/pages_language_overlay.php
@@ -66,7 +66,13 @@ $tempColumns = array(
                     'type'         => 'popup',
                     'title'        => 'Link',
                     'icon'         => 'link_popup.gif',
-                    'script'       => 'browse_links.php?mode=wizard&act=url',
+                    'module' => array(
+                        'name' => 'wizard_element_browser',
+                        'urlParameters' => array(
+                            'mode' => 'wizard',
+                            'act' => 'url'
+                        )
+                    ),
                     'params'       => array(
                         'blindLinkOptions' => 'mail',
                     ),


### PR DESCRIPTION
 of script=path/to/script.php in TCA. Makes the pages backend form work in TYPO3 7.4.