### PR TITLE
[BUGFIX][FEATURE] use CSRF for Ajax, add compatibility fixes for 7.5.0-dev 

### DIFF
--- a/Classes/Backend/Module/AbstractModule.php
+++ b/Classes/Backend/Module/AbstractModule.php
@@ -107,16 +107,4 @@ abstract class AbstractModule extends ActionController
 
         return $token;
     }
-
-    /**
-     * Ajax controller url
-     *
-     * @param   string $ajaxCall Ajax Call
-     *
-     * @return  string
-     */
-//    protected function ajaxControllerUrl($ajaxCall)
-//    {
-//        return $this->doc->backPath . 'ajax.php?ajaxID=' . urlencode($ajaxCall);
-//    }
 }

--- a/Classes/Backend/Module/AbstractModule.php
+++ b/Classes/Backend/Module/AbstractModule.php
@@ -46,15 +46,6 @@ abstract class AbstractModule extends ActionController
      */
     protected $formProtection;
 
-    // Internal, dynamic:
-    /**
-     * document template object
-     *
-     * @var \TYPO3\CMS\Backend\Template\DocumentTemplate
-     * @todo Define visibility
-     */
-    public $doc;
-
     // ########################################################################
     // Methods
     // ########################################################################
@@ -124,8 +115,8 @@ abstract class AbstractModule extends ActionController
      *
      * @return  string
      */
-    protected function ajaxControllerUrl($ajaxCall)
-    {
-        return $this->doc->backPath . 'ajax.php?ajaxID=' . urlencode($ajaxCall);
-    }
+//    protected function ajaxControllerUrl($ajaxCall)
+//    {
+//        return $this->doc->backPath . 'ajax.php?ajaxID=' . urlencode($ajaxCall);
+//    }
 }

--- a/Classes/Controller/BackendControlCenterController.php
+++ b/Classes/Controller/BackendControlCenterController.php
@@ -130,8 +130,7 @@ class BackendControlCenterController extends AbstractStandardModule
 
             // Settings available
             $page['settingsLink'] = Typo3BackendUtility::editOnClick(
-                '&edit[tx_metaseo_setting_root][' . $rootSettingList[$pageId]['uid'] . ']=edit',
-                $this->doc->backPath
+                '&edit[tx_metaseo_setting_root][' . $rootSettingList[$pageId]['uid'] . ']=edit'
             );
 
             $page['sitemapLink']   = RootPageUtility::getSitemapIndexUrl($pageId);

--- a/Classes/Controller/BackendPageSeoController.php
+++ b/Classes/Controller/BackendPageSeoController.php
@@ -149,7 +149,7 @@ class BackendPageSeoController extends AbstractStandardModule
 
         $metaSeoConf = array(
             'sessionToken'     => $this->sessionToken('metaseo_metaseo_backend_ajax_pageajax'),
-            'ajaxController'   => $this->ajaxControllerUrl('tx_metaseo_backend_ajax::page'),
+            'ajaxController'   => 'tx_metaseo_backend_ajax::page',
             'pid'              => (int)$pageId,
             'renderTo'         => 'tx-metaseo-sitemap-grid',
             'pagingSize'       => 50,

--- a/Classes/Controller/BackendRootSettingsController.php
+++ b/Classes/Controller/BackendRootSettingsController.php
@@ -128,8 +128,7 @@ class BackendRootSettingsController extends AbstractStandardModule
 
             // Settings available
             $page['settingsLink'] = Typo3BackendUtility::editOnClick(
-                '&edit[tx_metaseo_setting_root][' . $rootSettingList[$pageId]['uid'] . ']=edit',
-                $this->doc->backPath
+                '&edit[tx_metaseo_setting_root][' . $rootSettingList[$pageId]['uid'] . ']=edit'
             );
         }
         unset($page);

--- a/Classes/Controller/BackendSitemapController.php
+++ b/Classes/Controller/BackendSitemapController.php
@@ -264,7 +264,7 @@ class BackendSitemapController extends AbstractStandardModule
 
         $metaSeoConf = array(
             'sessionToken'          => $this->sessionToken('metaseo_metaseo_backend_ajax_sitemapajax'),
-            'ajaxController'        => $this->ajaxControllerUrl('tx_metaseo_backend_ajax::sitemap'),
+            'ajaxController'        => 'tx_metaseo_backend_ajax::sitemap',
             'pid'                   => (int)$rootPid,
             'renderTo'              => 'tx-metaseo-sitemap-grid',
             'pagingSize'            => 50,

--- a/Classes/Hook/TCA/RobotsTxtDefault.php
+++ b/Classes/Hook/TCA/RobotsTxtDefault.php
@@ -125,6 +125,30 @@ class RobotsTxtDefault
         $content = htmlspecialchars($content);
         $content = nl2br($content);
 
+        /**
+         * instanciation of TypoScriptFrontendController instanciates PageRenderer which
+         * sets backPath to TYPO3_mainDir which is very bad in the Backend. Therefore,
+         * we must set it back to null to not get frontend-prefixed asset URLs. See #150.
+         */
+        $this->cleanUpPageRendererBackPath();
+
         return $content;
+    }
+
+    /**
+     * Sets backPath of PageRenderer back to null (for Backend)
+     */
+    protected function cleanUpPageRendererBackPath()
+    {
+        $pageRenderer = $this->getPageRenderer();
+        $pageRenderer->setBackPath(null);
+    }
+
+    /**
+     * @return \TYPO3\CMS\Core\Page\PageRenderer
+     */
+    protected function getPageRenderer()
+    {
+        return GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Page\\PageRenderer');
     }
 }

--- a/Classes/Utility/BackendUtility.php
+++ b/Classes/Utility/BackendUtility.php
@@ -26,6 +26,9 @@
 
 namespace Metaseo\Metaseo\Utility;
 
+use TYPO3\CMS\Core\Utility\GeneralUtility as Typo3GeneralUtility;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+
 /**
  * Backend utility
  */
@@ -75,5 +78,44 @@ class BackendUtility
         }
 
         return $cache;
+    }
+
+    /**
+     * Returns the Ajax URL for a given AjaxID including a CSRF token.
+     *
+     * This function is mostly copied from the core, because it should not be used directly.
+     * You need to test it at first usage in this project and eventually use the latest version from the core.
+     * See #147 to learn about TYPO3's deprecation concept and our refactoring concept.
+     *
+     * Ajax URLs of all registered backend Ajax handlers are automatically published
+     * to JavaScript inline settings: TYPO3.settings.ajaxUrls['ajaxId']
+     *
+     * @param string $ajaxIdentifier Identifier of the AJAX callback
+     * @param array $urlParameters URL parameters that should be added as key value pairs
+     * @param bool $returnAbsoluteUrl If set to TRUE, the URL returned will be absolute,
+     *                                $backPathOverride will be ignored in this case
+     *
+     * @return string Calculated URL
+     * @internal
+     */
+    public static function getAjaxUrl(
+        $ajaxIdentifier,
+        array $urlParameters = array(),
+        $returnAbsoluteUrl = false
+    ) {
+        return self::getUriBuilder()
+            ->buildUriFromAjaxId(
+                $ajaxIdentifier,
+                $urlParameters,
+                $returnAbsoluteUrl ? UriBuilder::ABSOLUTE_URL : UriBuilder::ABSOLUTE_PATH
+            );
+    }
+
+    /**
+     * @return UriBuilder
+     */
+    public static function getUriBuilder()
+    {
+        return Typo3GeneralUtility::makeInstance('\\TYPO3\\CMS\\Backend\\Routing\\UriBuilder');
     }
 }

--- a/Configuration/TCA/MetaseoSettingRoot.php
+++ b/Configuration/TCA/MetaseoSettingRoot.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ *  Copyright notice
+ *
+ *  (c) 2015 Markus Blaschke <typo3@markus-blaschke.de> (metaseo)
+ *  (c) 2013 Markus Blaschke (TEQneers GmbH & Co. KG) <blaschke@teqneers.de> (tq_seo)
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ */
+
+namespace Metaseo\Configuration\TCA;
+
+/**
+ * This File is include()d by TYPO3's ExtensionUtility. We'll get an exception when we remove it.
+ * At some time we should find out what this file is actually good for.
+ */

--- a/Resources/Public/Backend/JavaScript/MetaSeo.overview.js
+++ b/Resources/Public/Backend/JavaScript/MetaSeo.overview.js
@@ -301,8 +301,10 @@ MetaSeo.overview.grid = {
                                         grid.getStore().load();
                                     };
 
+                                    var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.overview.conf.ajaxController] + '&cmd=updatePageFieldRecursively';
+
                                     Ext.Ajax.request({
-                                        url: MetaSeo.overview.conf.ajaxController + '&cmd=updatePageFieldRecursively',
+                                        url: ajaxUrl,
                                         params: {
                                             pid             : Ext.encode(pid),
                                             field           : Ext.encode(fieldName),
@@ -337,8 +339,10 @@ MetaSeo.overview.grid = {
                                         grid.getStore().load();
                                     };
 
+                                    var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.overview.conf.ajaxController] + '&cmd=updatePageField';
+
                                     Ext.Ajax.request({
-                                        url: MetaSeo.overview.conf.ajaxController + '&cmd=updatePageField',
+                                        url: ajaxUrl,
                                         params: {
                                             pid: Ext.encode(pid),
                                             field: Ext.encode(fieldName),
@@ -460,11 +464,13 @@ MetaSeo.overview.grid = {
                 break;
         }
 
-        var gridDs = new Ext.data.Store({
+        var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.overview.conf.ajaxController] + '&cmd=getList';
+
+        return new Ext.data.Store({
             storeId: 'MetaSeoOverviewRecordsStore',
             autoLoad: true,
             remoteSort: true,
-            url: MetaSeo.overview.conf.ajaxController + '&cmd=getList',
+            url: ajaxUrl,
             reader: new Ext.data.JsonReader({
                     totalProperty: 'results',
                     root: 'rows'
@@ -495,8 +501,6 @@ MetaSeo.overview.grid = {
                 }
             }
         });
-
-        return gridDs;
     },
 
 
@@ -911,8 +915,10 @@ MetaSeo.overview.grid = {
                                 }
                             };
 
+                            var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.overview.conf.ajaxController] + '&cmd=generateSimulatedUrl';
+
                             Ext.Ajax.request({
-                                url: MetaSeo.overview.conf.ajaxController + '&cmd=generateSimulatedUrl',
+                                url: ajaxUrl,
                                 params: {
                                     pid: Ext.encode(record.get('uid')),
                                     sessionToken: Ext.encode(MetaSeo.overview.conf.sessionToken)
@@ -997,8 +1003,10 @@ MetaSeo.overview.grid = {
                             }
                         };
 
+                        var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.overview.conf.ajaxController] + '&cmd=generateSimulatedTitle';
+
                         Ext.Ajax.request({
-                            url: MetaSeo.overview.conf.ajaxController + '&cmd=generateSimulatedTitle',
+                            url: ajaxUrl,
                             params: {
                                 pid: Ext.encode(record.get('uid')),
                                 sessionToken: Ext.encode(MetaSeo.overview.conf.sessionToken)

--- a/Resources/Public/Backend/JavaScript/MetaSeo.overview.js
+++ b/Resources/Public/Backend/JavaScript/MetaSeo.overview.js
@@ -61,6 +61,17 @@ MetaSeo.overview.grid = {
         var me = this;
 
         /****************************************************
+         * check if we got a page
+         ****************************************************/
+        if (!('conf' in MetaSeo.overview)) {
+            return;
+        }
+
+        if (!('listType' in MetaSeo.overview.conf)) {
+            return;
+        }
+
+        /****************************************************
          * settings
          ****************************************************/
         switch (MetaSeo.overview.conf.listType) {

--- a/Resources/Public/Backend/JavaScript/MetaSeo.sitemap.js
+++ b/Resources/Public/Backend/JavaScript/MetaSeo.sitemap.js
@@ -37,11 +37,14 @@ MetaSeo.sitemap.grid = {
         /****************************************************
          * grid storage
          ****************************************************/
+
+        var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.sitemap.conf.ajaxController] + '&cmd=getList';
+
         var gridDs = new Ext.data.Store({
             storeId: 'MetaSeoSitemapRecordsStore',
             autoLoad: true,
             remoteSort: true,
-            url: MetaSeo.sitemap.conf.ajaxController + '&cmd=getList',
+            url: ajaxUrl,
             reader: new Ext.data.JsonReader({
                     totalProperty: 'results',
                     root: 'rows'
@@ -121,7 +124,7 @@ MetaSeo.sitemap.grid = {
         };
 
         var function_delete_all = function (ob) {
-            var cmd = "deleteAll";
+            var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.sitemap.conf.ajaxController] + '&cmd=deleteAll';
 
             var frmConfirm = new Ext.Window({
                 xtype: 'form',
@@ -140,7 +143,7 @@ MetaSeo.sitemap.grid = {
                         text: MetaSeo.sitemap.conf.lang.buttonYes,
                         handler: function (cmp, e) {
                             Ext.Ajax.request({
-                                url: MetaSeo.sitemap.conf.ajaxController + '&cmd=' + cmd,
+                                url: ajaxUrl,
                                 params: {
                                     'pid': MetaSeo.sitemap.conf.pid,
                                     sessionToken: Ext.encode(MetaSeo.sitemap.conf.sessionToken)
@@ -176,6 +179,7 @@ MetaSeo.sitemap.grid = {
 
         var rowAction = function (ob, cmd, confirmTitle, confirmText) {
             var recList = grid.getSelectionModel().getSelections();
+            var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.sitemap.conf.ajaxController] + '&cmd=' + cmd;
 
             if (recList.length >= 1) {
                 var uidList = [];
@@ -199,7 +203,7 @@ MetaSeo.sitemap.grid = {
                             text: MetaSeo.sitemap.conf.lang.buttonYes,
                             handler: function (cmp, e) {
                                 Ext.Ajax.request({
-                                    url: MetaSeo.sitemap.conf.ajaxController + '&cmd=' + cmd,
+                                    url: ajaxUrl,
                                     params: {
                                         'uidList': Ext.encode(uidList),
                                         'pid': MetaSeo.sitemap.conf.pid,

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -7,12 +7,6 @@ $confArr = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['metaseo'])
 // BACKEND
 // ##############################################
 if (TYPO3_MODE == 'BE') {
-    // AJAX
-    $GLOBALS['TYPO3_CONF_VARS']['BE']['AJAX']['tx_metaseo_backend_ajax::sitemap']
-        = 'Metaseo\\Metaseo\\Backend\\Ajax\SitemapAjax->main';
-    $GLOBALS['TYPO3_CONF_VARS']['BE']['AJAX']['tx_metaseo_backend_ajax::page']
-        = 'Metaseo\\Metaseo\\Backend\\Ajax\PageAjax->main';
-
     // Field validations
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tce']['formevals']['tx_metaseo_backend_validation_float']
         = 'EXT:metaseo/Classes/Backend/Validator/ValidatorImport.php';

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -80,6 +80,17 @@ if (TYPO3_MODE == 'BE') {
             'labels' => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/ModuleSitemap/locallang.xlf',
         )
     );
+
+    // AJAX
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerAjaxHandler(
+        'tx_metaseo_backend_ajax::sitemap',
+        'Metaseo\\Metaseo\\Backend\\Ajax\SitemapAjax->main'
+    );
+
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerAjaxHandler(
+        'tx_metaseo_backend_ajax::page',
+        'Metaseo\\Metaseo\\Backend\\Ajax\PageAjax->main'
+    );
 }
 
 // ############################################################################


### PR DESCRIPTION
* Add CSRF protection and refactoring steps (deprecation/breaking changes)
* Add compatibilty fixes for the backend of 7.5.0-dev. Status: backend is fully functional.
* Changes should be compatible to 6.2.14.