### PR TITLE
[TASK] OOP: Refactor Ajax controllers

### DIFF
--- a/Classes/Backend/Ajax/PageAjax.php
+++ b/Classes/Backend/Ajax/PageAjax.php
@@ -158,7 +158,7 @@ class PageAjax extends AbstractAjax
                     )
                 );*/
 
-                $list = $this->listDefaultTree($page, $depth, $sysLanguage, $fieldList, true);
+                $list = $this->listDefaultTree($page, $depth, $sysLanguage, $fieldList);
                 break;
             case 'pagetitle':
                 $fieldList = array_merge(
@@ -200,11 +200,10 @@ class PageAjax extends AbstractAjax
      * @param   integer $depth             Depth
      * @param   integer $sysLanguage       System language
      * @param   array   $fieldList         Field list
-     * @param   boolean $enableAdvMetaTags Enable adv. meta tags
      *
      * @return  array
      */
-    protected function listDefaultTree(array $page, $depth, $sysLanguage, array $fieldList, $enableAdvMetaTags = false)
+    protected function listDefaultTree(array $page, $depth, $sysLanguage, array $fieldList)
     {
         $rootPid = $page['uid'];
 
@@ -377,11 +376,6 @@ class PageAjax extends AbstractAjax
      */
     protected function listPageTitleSim(array $page, $depth, $sysLanguage)
     {
-        // Init
-        $list = array();
-
-        $pid = $page['uid'];
-
         $fieldList = array(
             'title',
             'tx_metaseo_pagetitle',
@@ -453,9 +447,6 @@ class PageAjax extends AbstractAjax
         array $rootlineFull = null,
         $sysLanguage = null
     ) {
-        static $cacheTSFE = array();
-        static $lastTsSetupPid = null;
-
         $pageUid = (int)$page['uid'];
 
         if ($rootLine === null) {

--- a/Classes/Controller/AbstractAjaxController.php
+++ b/Classes/Controller/AbstractAjaxController.php
@@ -24,7 +24,7 @@
  *  This copyright notice MUST APPEAR in all copies of the script!
  */
 
-namespace Metaseo\Metaseo\Backend\Ajax;
+namespace Metaseo\Metaseo\Controller;
 
 use Exception;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -32,7 +32,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * TYPO3 Backend ajax module base
  */
-abstract class AbstractAjax
+abstract class AbstractAjaxController
 {
     /**
      * Json status indicators

--- a/Classes/Controller/Ajax/AbstractPageSeoController.php
+++ b/Classes/Controller/Ajax/AbstractPageSeoController.php
@@ -25,8 +25,9 @@
  */
 
 
-namespace Metaseo\Metaseo\Backend\Ajax;
+namespace Metaseo\Metaseo\Controller\Ajax;
 
+use Metaseo\Metaseo\Controller\AbstractAjaxController;
 use Metaseo\Metaseo\Utility\DatabaseUtility;
 use Metaseo\Metaseo\Utility\FrontendUtility;
 use Metaseo\Metaseo\Utility\GeneralUtility;
@@ -37,7 +38,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility as Typo3GeneralUtility;
 /**
  * TYPO3 Backend ajax module page
  */
-class PageAjax extends AbstractAjax
+class AbstractPageSeoController extends AbstractAjaxController
 {
 
     // ########################################################################

--- a/Classes/Controller/Ajax/AbstractPageSeoController.php
+++ b/Classes/Controller/Ajax/AbstractPageSeoController.php
@@ -27,19 +27,26 @@
 
 namespace Metaseo\Metaseo\Controller\Ajax;
 
+use Metaseo\Metaseo\Exception\Ajax\AjaxException;
 use Metaseo\Metaseo\Controller\AbstractAjaxController;
+use Metaseo\Metaseo\Controller\Ajax\PageSeo\AdvancedController;
+use Metaseo\Metaseo\Controller\Ajax\PageSeo\GeoController;
+use Metaseo\Metaseo\Controller\Ajax\PageSeo\MetaDataController;
+use Metaseo\Metaseo\Controller\Ajax\PageSeo\PageTitleController;
+use Metaseo\Metaseo\Controller\Ajax\PageSeo\PageTitleSimController;
+use Metaseo\Metaseo\Controller\Ajax\PageSeo\SearchEnginesController;
+use Metaseo\Metaseo\Controller\Ajax\PageSeo\UrlController;
 use Metaseo\Metaseo\Utility\DatabaseUtility;
 use Metaseo\Metaseo\Utility\FrontendUtility;
-use Metaseo\Metaseo\Utility\GeneralUtility;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3\CMS\Core\Utility\GeneralUtility as Typo3GeneralUtility;
 
 /**
  * TYPO3 Backend ajax module page
  */
-class AbstractPageSeoController extends AbstractAjaxController
+abstract class AbstractPageSeoController extends AbstractAjaxController implements PageSeoInterface
 {
+    const LIST_TYPE = 'undefined';
+    const AJAX_PREFIX = 'tx_metaseo_controller_ajax_pageseo_';
 
     // ########################################################################
     // Attributes
@@ -50,23 +57,49 @@ class AbstractPageSeoController extends AbstractAjaxController
      *
      * @var    array
      */
-    protected $templatePidList = array();
+    protected $templatePidList;
+
+    /**
+     * @var array
+     */
+    protected $fieldList;
 
     // ########################################################################
     // Methods
     // ########################################################################
 
+    public function __construct()
+    {
+        parent::__construct();
+        $this->templatePidList = array();
+        $this->initFieldList();
+    }
+
+    abstract protected function initFieldList();
+
     /**
-     * Return overview entry list for root tree
-     *
+     * @inheritDoc
+     */
+    public function indexAction()
+    {
+        try {
+            $this->init();
+            $ret = $this->executeIndex();
+        } catch (AjaxException $ajaxException) {
+            return $this->ajaxErrorHandler($ajaxException);
+        }
+
+        return $this->ajaxSuccess($ret);
+    }
+
+    /**
      * @return array
      */
-    protected function executeGetList()
+    protected function executeIndex()
     {
         $pid         = (int)$this->postVar['pid'];
         $depth       = (int)$this->postVar['depth'];
         $sysLanguage = (int)$this->postVar['sysLanguage'];
-        $listType    = (string)$this->postVar['listType'];
 
         // Store last selected language
         $this->getBackendUserAuthentication()
@@ -83,115 +116,28 @@ class AbstractPageSeoController extends AbstractAjaxController
 
         $page = BackendUtility::getRecord('pages', $pid);
 
-        $fieldList = array();
+        $list = $this->getIndex($page, $depth, $sysLanguage);
 
-        switch ($listType) {
-            case 'metadata':
-                $fieldList = array_merge(
-                    $fieldList,
-                    array(
-                        'keywords',
-                        'description',
-                        'abstract',
-                        'author',
-                        'author_email',
-                        'lastupdated',
-                    )
-                );
-
-                $list = $this->listDefaultTree($page, $depth, $sysLanguage, $fieldList);
-
-                unset($row);
-                foreach ($list as &$row) {
-                    if (!empty($row['lastupdated'])) {
-                        $row['lastupdated'] = date('Y-m-d', $row['lastupdated']);
-                    } else {
-                        $row['lastupdated'] = '';
-                    }
-                }
-                unset($row);
-                break;
-            case 'geo':
-                $fieldList = array_merge(
-                    $fieldList,
-                    array(
-                        'tx_metaseo_geo_lat',
-                        'tx_metaseo_geo_long',
-                        'tx_metaseo_geo_place',
-                        'tx_metaseo_geo_region'
-                    )
-                );
-
-                $list = $this->listDefaultTree($page, $depth, $sysLanguage, $fieldList);
-                break;
-            case 'searchengines':
-                $fieldList = array_merge(
-                    $fieldList,
-                    array(
-                        'tx_metaseo_canonicalurl',
-                        'tx_metaseo_is_exclude',
-                        'tx_metaseo_priority',
-                    )
-                );
-
-                $list = $this->listDefaultTree($page, $depth, $sysLanguage, $fieldList);
-                break;
-            case 'url':
-                $fieldList = array_merge(
-                    $fieldList,
-                    array(
-                        'title',
-                        'url_scheme',
-                        'alias',
-                        'tx_realurl_pathsegment',
-                        'tx_realurl_pathoverride',
-                        'tx_realurl_exclude',
-                    )
-                );
-
-                $list = $this->listDefaultTree($page, $depth, $sysLanguage, $fieldList);
-                break;
-            case 'advanced':
-                /*
-                $fieldList = array_merge(
-                    $fieldList,
-                    array(// Maybe we need more fields later
-                    )
-                );*/
-
-                $list = $this->listDefaultTree($page, $depth, $sysLanguage, $fieldList);
-                break;
-            case 'pagetitle':
-                $fieldList = array_merge(
-                    $fieldList,
-                    array(
-                        'tx_metaseo_pagetitle',
-                        'tx_metaseo_pagetitle_rel',
-                        'tx_metaseo_pagetitle_prefix',
-                        'tx_metaseo_pagetitle_suffix',
-                    )
-                );
-
-                $list = $this->listDefaultTree($page, $depth, $sysLanguage, $fieldList);
-                break;
-            case 'pagetitlesim':
-                $list = $this->listPageTitleSim($page, $depth, $sysLanguage);
-                break;
-            default:
-                // Not defined
-                return $this->ajaxErrorTranslate(
-                    'message.error.unknown_list_type_received',
-                    '[0x4FBF3C0D]',
-                    self::HTTP_STATUS_BAD_REQUEST
-                );
-        }
-
-        return $this->ajaxSuccess(
-            array(
-                'results' => count($list),
-                'rows'    => array_values($list),
-            )
+        return array(
+            'results' => count($list),
+            'rows'    => array_values($list),
         );
+    }
+
+    /**
+     * Return default tree
+     *
+     * This function is made for list manipulation in subclasses (method template design pattern)
+     *
+     * @param   array   $page              Root page
+     * @param   integer $depth             Depth
+     * @param   integer $sysLanguage       System language
+     *
+     * @return  array
+     */
+    protected function getIndex(array $page, $depth, $sysLanguage)
+    {
+        return $this->index($page, $depth, $sysLanguage, $this->fieldList);
     }
 
     /**
@@ -204,7 +150,7 @@ class AbstractPageSeoController extends AbstractAjaxController
      *
      * @return  array
      */
-    protected function listDefaultTree(array $page, $depth, $sysLanguage, array $fieldList)
+    protected function index(array $page, $depth, $sysLanguage, $fieldList = array())
     {
         $rootPid = $page['uid'];
 
@@ -233,7 +179,6 @@ class AbstractPageSeoController extends AbstractAjaxController
         );
 
         $tree->getTree($rootPid, $depth, '');
-
 
         // Build tree list
         foreach ($tree->tree as $row) {
@@ -367,70 +312,6 @@ class AbstractPageSeoController extends AbstractAjaxController
     }
 
     /**
-     * Return simulated page title
-     *
-     * @param   array   $page        Root page
-     * @param   integer $depth       Depth
-     * @param   integer $sysLanguage Sys language
-     *
-     * @return  array
-     */
-    protected function listPageTitleSim(array $page, $depth, $sysLanguage)
-    {
-        $fieldList = array(
-            'title',
-            'tx_metaseo_pagetitle',
-            'tx_metaseo_pagetitle_rel',
-            'tx_metaseo_pagetitle_prefix',
-            'tx_metaseo_pagetitle_suffix',
-        );
-
-        $list = $this->listDefaultTree($page, $depth, $sysLanguage, $fieldList);
-
-        $uidList = array_keys($list);
-
-        if (!empty($uidList)) {
-            // Check which pages have templates (for caching and faster building)
-            $this->templatePidList = array();
-
-            $query   = 'SELECT pid
-                          FROM sys_template
-                         WHERE pid IN (' . implode(',', $uidList) . ')
-                           AND deleted = 0
-                           AND hidden = 0';
-            $pidList = DatabaseUtility::getCol($query);
-            foreach ($pidList as $pid) {
-                $this->templatePidList[$pid] = $pid;
-            }
-
-            // Build simulated title
-            foreach ($list as &$row) {
-                $row['title_simulated'] = $this->simulateTitle($row, $sysLanguage);
-            }
-        }
-
-        return $list;
-    }
-
-    /**
-     * Generate simulated page title
-     *
-     * @param   array   $page        Page
-     * @param   integer $sysLanguage System language
-     *
-     * @return  string
-     */
-    protected function simulateTitle(array $page, $sysLanguage)
-    {
-        $this->initTsfe($page, null, $page, null, $sysLanguage);
-
-        $pagetitle = $this->objectManager->get('Metaseo\\Metaseo\\Page\\Part\\PagetitlePart');
-        $ret       = $pagetitle->main($page['title']);
-
-        return $ret;
-    }
-
-    /**
      * Init TSFE (for simulated pagetitle)
      *
      * @param   array        $page         Page
@@ -484,117 +365,25 @@ class AbstractPageSeoController extends AbstractAjaxController
     }
 
     /**
-     * Generate simulated title for one page
-     *
-     * @return    array
+     * @inheritDoc
      */
-    protected function executeGenerateSimulatedTitle()
+    public function updateAction()
     {
-        // Init
-        $pid = (int)$this->postVar['pid'];
+        try {
+            $this->init();
+            $ret = $this->executeUpdate();
 
-        if (empty($pid)) {
-
-            return $this->ajaxErrorTranslate(
-                'message.error.typo3_page_not_found',
-                '[0x4FBF3C08]',
-                self::HTTP_STATUS_BAD_REQUEST
-            );
+        } catch (AjaxException $ajaxException) {
+            return $this->ajaxErrorHandler($ajaxException);
         }
 
-        $page = BackendUtility::getRecord('pages', $pid);
-
-        if (empty($page)) {
-
-            return $this->ajaxErrorTranslate(
-                'message.error.typo3_page_not_found',
-                '[0x4FBF3C09]',
-                self::HTTP_STATUS_BAD_REQUEST
-            );
-        }
-
-        // Load TYPO3 classes
-        $this->initTsfe($page, null, $page, null);
-
-        $pagetitle = Typo3GeneralUtility::makeInstance(
-            'Metaseo\\Metaseo\\Page\\Part\\PagetitlePart'
-        );
-        $ret       = $pagetitle->main($page['title']);
-
-        return $this->ajaxSuccess(
-            array(
-                'title' => $ret,
-            )
-        );
+        return $this->ajaxSuccess($ret);
     }
 
     /**
-     * Generate simulated title for one page
-     *
      * @return array
      */
-    protected function executeGenerateSimulatedUrl()
-    {
-        // Init
-        $pid = (int)$this->postVar['pid'];
-
-        if (empty($pid)) {
-
-            return $this->ajaxErrorTranslate(
-                'message.error.typo3_page_not_found',
-                '[0x4FBF3C0A]',
-                self::HTTP_STATUS_BAD_REQUEST
-            );
-        }
-
-        $page = BackendUtility::getRecord('pages', $pid);
-
-        if (empty($page)) {
-
-            return $this->ajaxErrorTranslate(
-                'message.error.typo3_page_not_found',
-                '[0x4FBF3C0B]',
-                self::HTTP_STATUS_BAD_REQUEST
-            );
-        }
-
-        if (ExtensionManagementUtility::isLoaded('realurl')) {
-            // Disable caching for url
-            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['enableUrlDecodeCache'] = 0;
-            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['enableUrlEncodeCache'] = 0;
-            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['disablePathCache']     = 1;
-        }
-
-        $this->initTsfe($page, null, $page, null);
-
-        $ret = $GLOBALS['TSFE']->cObj->typolink_URL(array('parameter' => $page['uid']));
-
-        if (!empty($ret)) {
-            $ret = GeneralUtility::fullUrl($ret);
-        }
-
-        if (empty($ret)) {
-
-            return $this->ajaxErrorTranslate(
-                'message.error.url_generation_failed',
-                '[0x4FBF3C01]',
-                self::HTTP_STATUS_BAD_REQUEST
-            );
-        }
-
-        return $this->ajaxSuccess(
-            array(
-                'url' => $ret,
-            )
-        );
-    }
-
-    /**
-     * Update page field
-     *
-     * @return array
-     */
-    protected function executeUpdatePageField()
+    protected function executeUpdate()
     {
         if (empty($this->postVar['pid']) || empty($this->postVar['field'])) {
 
@@ -610,8 +399,14 @@ class AbstractPageSeoController extends AbstractAjaxController
         $fieldValue  = (string)$this->postVar['value'];
         $sysLanguage = (int)$this->postVar['sysLanguage'];
 
-        // validate field name
-        $fieldName = preg_replace('/[^-_a-zA-Z0-9:]/i', '', $fieldName);
+        // validate field name: must match exactly to list of known field names
+        if (!in_array($fieldName, array_merge($this->fieldList, array('title')))) {
+            return $this->ajaxErrorTranslate(
+                'message.warning.incomplete_data_received.message',
+                '[0x4FBF3C23]',
+                self::HTTP_STATUS_BAD_REQUEST
+            );
+        }
 
         if (empty($fieldName)) {
 
@@ -707,19 +502,30 @@ class AbstractPageSeoController extends AbstractAjaxController
         // ############################
         // Update
         // ############################
-        $ret = $this->updatePageTableField($pid, $sysLanguage, $fieldName, $fieldValue);
+
+        return $this->updatePageTableField($pid, $sysLanguage, $fieldName, $fieldValue);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function updateRecursiveAction()
+    {
+        try {
+            $this->init();
+            $ret = $this->executeUpdateRecursive();
+        } catch (AjaxException $ajaxException) {
+            return $this->ajaxErrorHandler($ajaxException);
+        }
 
         return $this->ajaxSuccess($ret);
     }
 
     /**
-     * Update page field recursively.
-     *
      * @return array
      */
-    protected function executeUpdatePageFieldRecursively()
+    protected function executeUpdateRecursive()
     {
-
         if (empty($this->postVar['pid']) || empty($this->postVar['field'])) {
 
             return $this->ajaxErrorTranslate(
@@ -731,17 +537,20 @@ class AbstractPageSeoController extends AbstractAjaxController
 
         $pid         = $this->postVar['pid'];
         $sysLanguage = (int)$this->postVar['sysLanguage'];
-        $fieldList   = array();
 
         $page = BackendUtility::getRecord('pages', $pid);
-        $list = $this->listDefaultTree($page, 999, $sysLanguage, $fieldList);
+        $list = $this->index($page, 999, $sysLanguage, array());
 
+        $count = 0;
         foreach ($list as $key => $page) {
             $this->postVar['pid'] = $key;
-            $this->executeUpdatePageField();
+            $this->executeUpdate();
+            $count++;
         }
 
-        return $this->ajaxSuccess();
+        return array(
+            'updateCount' => $count,  //not in use yet
+        );
     }
 
 
@@ -812,145 +621,37 @@ class AbstractPageSeoController extends AbstractAjaxController
                 break;
         }
 
-        return $this->ajaxSuccess();
+        return array();
     }
 
     /**
-     * Load meta data
+     * @inheritDoc
+     */
+    protected function getAjaxPrefix()
+    {
+        return self::AJAX_PREFIX;
+    }
+
+    /**
+     * Returns array of classes which contain Ajax controllers with <ajaxPrefix> => <className)
+     *
+     * @todo replace class concatenation with e.g. 'UrlController::class' as of PHP 5.5  (renders $namespace obsolete)
      *
      * @return array
      */
-    protected function executeLoadAdvMetaTags()
+    public static function getBackendAjaxClassNames()
     {
-        if (empty($this->postVar['pid'])) {
+        $nameSpace = __NAMESPACE__ . '\\PageSeo';
+        $ajaxPrefix = self::AJAX_PREFIX;
 
-            return $this->ajaxErrorTranslate(
-                'message.error.typo3_page_not_found',
-                '[0x4FBF3C0E]',
-                self::HTTP_STATUS_BAD_REQUEST
-            );
-        }
-
-        $ret = array();
-
-        $pid         = (int)$this->postVar['pid'];
-        $sysLanguage = (int)$this->postVar['sysLanguage'];
-
-
-        // check uid of pages language overlay
-        $query   = 'SELECT tag_name,
-                           tag_value
-                      FROM tx_metaseo_metatag
-                     WHERE pid = ' . (int)$pid . '
-                       AND sys_language_uid = ' . (int)$sysLanguage;
-        $rowList = DatabaseUtility::getAll($query);
-        foreach ($rowList as $row) {
-            $ret[$row['tag_name']] = $row['tag_value'];
-        }
-
-        return $this->ajaxSuccess($ret);
-    }
-
-    /**
-     * Update page field
-     *
-     * @return array
-     */
-    protected function executeUpdateAdvMetaTags()
-    {
-        if (empty($this->postVar['pid']) || empty($this->postVar['metaTags'])) {
-
-            return $this->ajaxErrorTranslate(
-                'message.error.typo3_page_not_found',
-                '[0x4FBF3C0F]',
-                self::HTTP_STATUS_BAD_REQUEST
-            );
-        }
-
-        $pid         = (int)$this->postVar['pid'];
-        $metaTagList = (array)$this->postVar['metaTags'];
-        $sysLanguage = (int)$this->postVar['sysLanguage'];
-
-
-        $this->clearMetaTags($pid, $sysLanguage);
-        $metaTagGroup = 2;
-        foreach ($metaTagList as $metaTagName => $metaTagValue) {
-            if (is_scalar($metaTagValue)) {
-                $metaTagValue = trim($metaTagValue);
-
-                if (strlen($metaTagValue) > 0) {
-                    $this->updateMetaTag($pid, $sysLanguage, $metaTagName, $metaTagValue);
-                }
-            } elseif (is_array($metaTagValue)) {
-                foreach ($metaTagValue as $subTagName => $subTagValue) {
-                    $this->updateMetaTag(
-                        $pid,
-                        $sysLanguage,
-                        array($metaTagName, $subTagName),
-                        $subTagValue,
-                        $metaTagGroup++
-                    );
-                }
-            }
-        }
-
-        return $this->ajaxSuccess();
-    }
-
-    /**
-     * Clear all meta tags for one page
-     *
-     * @param integer      $pid         PID
-     * @param integer|null $sysLanguage system language id
-     */
-    protected function clearMetaTags($pid, $sysLanguage)
-    {
-        $query = 'DELETE FROM tx_metaseo_metatag
-                        WHERE pid = ' . (int)$pid . '
-                          AND sys_language_uid = ' . (int)$sysLanguage;
-        DatabaseUtility::exec($query);
-    }
-
-    /**
-     * @param integer      $pid         PID
-     * @param integer|NULL $sysLanguage System language id
-     * @param string|array $metaTag     MetaTag name
-     * @param string       $value       MetaTag value
-     * @param integer      $tagGroup    MetaTag group
-     */
-    protected function updateMetaTag($pid, $sysLanguage, $metaTag, $value, $tagGroup = null)
-    {
-        $tstamp   = time();
-        $crdate   = time();
-        //TODO: Field user is internal!
-        $cruserId = $this->getBackendUserAuthentication()->user['uid'];
-
-        $subTagName = '';
-
-        if (is_array($metaTag)) {
-            list($metaTag, $subTagName) = $metaTag;
-        }
-
-        if ($tagGroup === null) {
-            $tagGroup = 1;
-        }
-
-        $query = 'INSERT INTO tx_metaseo_metatag
-                              (pid, tstamp, crdate, cruser_id, sys_language_uid,
-                                  tag_name, tag_subname, tag_value, tag_group)
-                       VALUES (
-                             ' . (int)$pid . ',
-                             ' . (int)$tstamp . ',
-                             ' . (int)$crdate . ',
-                             ' . (int)$cruserId . ',
-                             ' . (int)$sysLanguage . ',
-                             ' . DatabaseUtility::quote($metaTag) . ',
-                             ' . DatabaseUtility::quote($subTagName) . ',
-                             ' . DatabaseUtility::quote($value) . ',
-                             ' . (int)$tagGroup . '
-                       ) ON DUPLICATE KEY UPDATE
-                               tstamp    = VALUES(tstamp),
-                               tag_value = VALUES(tag_value)';
-        DatabaseUtility::execInsert($query);
+        return array(
+            //$ajaxPrefix . AdvancedController::LIST_TYPE      => $nameSpace . '\\' . 'AdvancedController',//unused
+            $ajaxPrefix . GeoController::LIST_TYPE           => $nameSpace . '\\' . 'GeoController',
+            $ajaxPrefix . MetaDataController::LIST_TYPE      => $nameSpace . '\\' . 'MetaDataController',
+            $ajaxPrefix . PageTitleController::LIST_TYPE     => $nameSpace . '\\' . 'PageTitleController',
+            $ajaxPrefix . PageTitleSimController::LIST_TYPE  => $nameSpace . '\\' . 'PageTitleSimController',
+            $ajaxPrefix . SearchEnginesController::LIST_TYPE => $nameSpace . '\\' . 'SearchEnginesController',
+            $ajaxPrefix . UrlController::LIST_TYPE           => $nameSpace . '\\' . 'UrlController',
+        );
     }
 }

--- a/Classes/Controller/Ajax/PageSeo/AdvancedController.php
+++ b/Classes/Controller/Ajax/PageSeo/AdvancedController.php
@@ -1,0 +1,181 @@
+<?php
+
+/*
+ *  Copyright notice
+ *
+ *  (c) 2015 Markus Blaschke <typo3@markus-blaschke.de> (metaseo)
+ *  (c) 2013 Markus Blaschke (TEQneers GmbH & Co. KG) <blaschke@teqneers.de> (tq_seo)
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ */
+
+namespace Metaseo\Metaseo\Controller\Ajax\PageSeo;
+
+use Metaseo\Metaseo\Controller\Ajax\AbstractPageSeoController;
+use Metaseo\Metaseo\Controller\Ajax\PageSeoInterface;
+use Metaseo\Metaseo\Utility\DatabaseUtility;
+
+class AdvancedController extends AbstractPageSeoController implements PageSeoInterface
+{
+    const LIST_TYPE = 'advanced';
+
+    /**
+     * @inheritDoc
+     */
+    protected function initFieldList()
+    {
+        $this->fieldList = array();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function executeIndex()
+    {
+        if (empty($this->postVar['pid'])) {
+
+            return $this->ajaxErrorTranslate(
+                'message.error.typo3_page_not_found',
+                '[0x4FBF3C0E]',
+                self::HTTP_STATUS_BAD_REQUEST
+            );
+        }
+
+        $ret = array();
+
+        $pid         = (int)$this->postVar['pid'];
+        $sysLanguage = (int)$this->postVar['sysLanguage'];
+
+
+        // check uid of pages language overlay
+        $query   = 'SELECT tag_name,
+                           tag_value
+                      FROM tx_metaseo_metatag
+                     WHERE pid = ' . (int)$pid . '
+                       AND sys_language_uid = ' . (int)$sysLanguage;
+        $rowList = DatabaseUtility::getAll($query);
+        foreach ($rowList as $row) {
+            $ret[$row['tag_name']] = $row['tag_value'];
+        }
+
+        return array(
+            'results' => count($ret),
+            'rows'    => array_values($ret),
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function executeUpdate()
+    {
+        if (empty($this->postVar['pid']) || empty($this->postVar['metaTags'])) {
+
+            return $this->ajaxErrorTranslate(
+                'message.error.typo3_page_not_found',
+                '[0x4FBF3C0F]',
+                self::HTTP_STATUS_BAD_REQUEST
+            );
+        }
+
+        $pid         = (int)$this->postVar['pid'];
+        $metaTagList = (array)$this->postVar['metaTags'];
+        $sysLanguage = (int)$this->postVar['sysLanguage'];
+
+
+        $this->clearMetaTags($pid, $sysLanguage);
+        $metaTagGroup = 2;
+        foreach ($metaTagList as $metaTagName => $metaTagValue) {
+            if (is_scalar($metaTagValue)) {
+                $metaTagValue = trim($metaTagValue);
+
+                if (strlen($metaTagValue) > 0) {
+                    $this->updateMetaTag($pid, $sysLanguage, $metaTagName, $metaTagValue);
+                }
+            } elseif (is_array($metaTagValue)) {
+                foreach ($metaTagValue as $subTagName => $subTagValue) {
+                    $this->updateMetaTag(
+                        $pid,
+                        $sysLanguage,
+                        array($metaTagName, $subTagName),
+                        $subTagValue,
+                        $metaTagGroup++
+                    );
+                }
+            }
+        }
+
+        return array();
+    }
+
+    /**
+     * Clear all meta tags for one page
+     *
+     * @param integer      $pid         PID
+     * @param integer|null $sysLanguage system language id
+     */
+    protected function clearMetaTags($pid, $sysLanguage)
+    {
+        $query = 'DELETE FROM tx_metaseo_metatag
+                        WHERE pid = ' . (int)$pid . '
+                          AND sys_language_uid = ' . (int)$sysLanguage;
+        DatabaseUtility::exec($query);
+    }
+
+    /**
+     * @param integer      $pid         PID
+     * @param integer|NULL $sysLanguage System language id
+     * @param string|array $metaTag     MetaTag name
+     * @param string       $value       MetaTag value
+     * @param integer      $tagGroup    MetaTag group
+     */
+    protected function updateMetaTag($pid, $sysLanguage, $metaTag, $value, $tagGroup = null)
+    {
+        $tstamp   = time();
+        $crdate   = time();
+        $cruserId = $this->getBackendUserAuthentication()->user['uid'];
+
+        $subTagName = '';
+
+        if (is_array($metaTag)) {
+            list($metaTag, $subTagName) = $metaTag;
+        }
+
+        if ($tagGroup === null) {
+            $tagGroup = 1;
+        }
+
+        $query = 'INSERT INTO tx_metaseo_metatag
+                              (pid, tstamp, crdate, cruser_id, sys_language_uid,
+                                  tag_name, tag_subname, tag_value, tag_group)
+                       VALUES (
+                             ' . (int)$pid . ',
+                             ' . (int)$tstamp . ',
+                             ' . (int)$crdate . ',
+                             ' . (int)$cruserId . ',
+                             ' . (int)$sysLanguage . ',
+                             ' . DatabaseUtility::quote($metaTag) . ',
+                             ' . DatabaseUtility::quote($subTagName) . ',
+                             ' . DatabaseUtility::quote($value) . ',
+                             ' . (int)$tagGroup . '
+                       ) ON DUPLICATE KEY UPDATE
+                               tstamp    = VALUES(tstamp),
+                               tag_value = VALUES(tag_value)';
+        DatabaseUtility::execInsert($query);
+    }
+}

--- a/Classes/Controller/Ajax/PageSeo/GeoController.php
+++ b/Classes/Controller/Ajax/PageSeo/GeoController.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ *  Copyright notice
+ *
+ *  (c) 2015 Markus Blaschke <typo3@markus-blaschke.de> (metaseo)
+ *  (c) 2013 Markus Blaschke (TEQneers GmbH & Co. KG) <blaschke@teqneers.de> (tq_seo)
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ */
+
+namespace Metaseo\Metaseo\Controller\Ajax\PageSeo;
+
+use Metaseo\Metaseo\Controller\Ajax\AbstractPageSeoController;
+use Metaseo\Metaseo\Controller\Ajax\PageSeoInterface;
+
+class GeoController extends AbstractPageSeoController implements PageSeoInterface
+{
+    const LIST_TYPE = 'geo';
+
+    /**
+     * @inheritDoc
+     */
+    protected function initFieldList()
+    {
+        $this->fieldList = array(
+            'tx_metaseo_geo_lat',
+            'tx_metaseo_geo_long',
+            'tx_metaseo_geo_place',
+            'tx_metaseo_geo_region'
+        );
+    }
+}

--- a/Classes/Controller/Ajax/PageSeo/MetaDataController.php
+++ b/Classes/Controller/Ajax/PageSeo/MetaDataController.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ *  Copyright notice
+ *
+ *  (c) 2015 Markus Blaschke <typo3@markus-blaschke.de> (metaseo)
+ *  (c) 2013 Markus Blaschke (TEQneers GmbH & Co. KG) <blaschke@teqneers.de> (tq_seo)
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ */
+
+namespace Metaseo\Metaseo\Controller\Ajax\PageSeo;
+
+use Metaseo\Metaseo\Controller\Ajax\AbstractPageSeoController;
+use Metaseo\Metaseo\Controller\Ajax\PageSeoInterface;
+
+class MetaDataController extends AbstractPageSeoController implements PageSeoInterface
+{
+    const LIST_TYPE = 'metadata';
+
+    protected function initFieldList()
+    {
+        $this->fieldList = array(
+            'keywords',
+            'description',
+            'abstract',
+            'author',
+            'author_email',
+            'lastupdated',
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getIndex(array $page, $depth, $sysLanguage)
+    {
+        $list = $this->index($page, $depth, $sysLanguage, $this->fieldList);
+
+        unset($row);
+        foreach ($list as &$row) {
+            if (!empty($row['lastupdated'])) {
+                $row['lastupdated'] = date('Y-m-d', $row['lastupdated']);
+            } else {
+                $row['lastupdated'] = '';
+            }
+        }
+        unset($row);
+
+        return $list;
+    }
+}

--- a/Classes/Controller/Ajax/PageSeo/PageTitleController.php
+++ b/Classes/Controller/Ajax/PageSeo/PageTitleController.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ *  Copyright notice
+ *
+ *  (c) 2015 Markus Blaschke <typo3@markus-blaschke.de> (metaseo)
+ *  (c) 2013 Markus Blaschke (TEQneers GmbH & Co. KG) <blaschke@teqneers.de> (tq_seo)
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ */
+
+namespace Metaseo\Metaseo\Controller\Ajax\PageSeo;
+
+use Metaseo\Metaseo\Controller\Ajax\AbstractPageSeoController;
+use Metaseo\Metaseo\Controller\Ajax\PageSeoInterface;
+
+class PageTitleController extends AbstractPageSeoController implements PageSeoInterface
+{
+    const LIST_TYPE = 'pagetitle';
+
+    /**
+     * @inheritDoc
+     */
+    protected function initFieldList()
+    {
+        $this->fieldList = array(
+            'tx_metaseo_pagetitle',
+            'tx_metaseo_pagetitle_rel',
+            'tx_metaseo_pagetitle_prefix',
+            'tx_metaseo_pagetitle_suffix',
+        );
+    }
+}

--- a/Classes/Controller/Ajax/PageSeo/PageTitleSimController.php
+++ b/Classes/Controller/Ajax/PageSeo/PageTitleSimController.php
@@ -1,0 +1,157 @@
+<?php
+
+/*
+ *  Copyright notice
+ *
+ *  (c) 2015 Markus Blaschke <typo3@markus-blaschke.de> (metaseo)
+ *  (c) 2013 Markus Blaschke (TEQneers GmbH & Co. KG) <blaschke@teqneers.de> (tq_seo)
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ */
+
+namespace Metaseo\Metaseo\Controller\Ajax\PageSeo;
+
+use Metaseo\Metaseo\Exception\Ajax\AjaxException;
+use Metaseo\Metaseo\Controller\Ajax\AbstractPageSeoController;
+use Metaseo\Metaseo\Controller\Ajax\PageSeoSimulateInterface;
+use Metaseo\Metaseo\Utility\DatabaseUtility;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility as Typo3GeneralUtility;
+
+class PageTitleSimController extends AbstractPageSeoController implements PageSeoSimulateInterface
+{
+    const LIST_TYPE = 'pagetitlesim';
+
+    /**
+     * @inheritDoc
+     */
+    protected function initFieldList()
+    {
+        $this->fieldList = array(
+            'title',
+            'tx_metaseo_pagetitle',
+            'tx_metaseo_pagetitle_rel',
+            'tx_metaseo_pagetitle_prefix',
+            'tx_metaseo_pagetitle_suffix',
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getIndex(array $page, $depth, $sysLanguage)
+    {
+        $list = $this->index($page, $depth, $sysLanguage, $this->fieldList);
+
+        $uidList = array_keys($list);
+
+        if (!empty($uidList)) {
+            // Check which pages have templates (for caching and faster building)
+            $this->templatePidList = array();
+
+            $query   = 'SELECT pid
+                          FROM sys_template
+                         WHERE pid IN (' . implode(',', $uidList) . ')
+                           AND deleted = 0
+                           AND hidden = 0';
+            $pidList = DatabaseUtility::getCol($query);
+            foreach ($pidList as $pid) {
+                $this->templatePidList[$pid] = $pid;
+            }
+
+            // Build simulated title
+            foreach ($list as &$row) {
+                $row['title_simulated'] = $this->simulateTitle($row, $sysLanguage);
+            }
+        }
+
+        return $list;
+    }
+
+    /**
+     * Generate simulated page title
+     *
+     * @param   array   $page        Page
+     * @param   integer $sysLanguage System language
+     *
+     * @return  string
+     */
+    protected function simulateTitle(array $page, $sysLanguage)
+    {
+        $this->initTsfe($page, null, $page, null, $sysLanguage);
+
+        $pagetitle = $this->objectManager->get('Metaseo\\Metaseo\\Page\\Part\\PagetitlePart');
+        $ret       = $pagetitle->main($page['title']);
+
+        return $ret;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function simulateAction()
+    {
+        try {
+            $this->init();
+            $ret = $this->executeSimulate();
+        } catch (AjaxException $ajaxException) {
+            return $this->ajaxErrorHandler($ajaxException);
+        }
+
+        return $this->ajaxSuccess($ret);
+    }
+
+    /**
+     * @return array
+     */
+    protected function executeSimulate()
+    {
+        $pid = (int)$this->postVar['pid'];
+
+        if (empty($pid)) {
+
+            return $this->ajaxErrorTranslate(
+                'message.error.typo3_page_not_found',
+                '[0x4FBF3C08]',
+                self::HTTP_STATUS_BAD_REQUEST
+            );
+        }
+
+        $page = BackendUtility::getRecord('pages', $pid);
+
+        if (empty($page)) {
+
+            return $this->ajaxErrorTranslate(
+                'message.error.typo3_page_not_found',
+                '[0x4FBF3C09]',
+                self::HTTP_STATUS_BAD_REQUEST
+            );
+        }
+
+        // Load TYPO3 classes
+        $this->initTsfe($page, null, $page, null);
+
+        $pagetitle = Typo3GeneralUtility::makeInstance(
+            'Metaseo\\Metaseo\\Page\\Part\\PagetitlePart'
+        );
+
+        return array(
+            'title' => $pagetitle->main($page['title']),
+        );
+    }
+}

--- a/Classes/Controller/Ajax/PageSeo/SearchEnginesController.php
+++ b/Classes/Controller/Ajax/PageSeo/SearchEnginesController.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ *  Copyright notice
+ *
+ *  (c) 2015 Markus Blaschke <typo3@markus-blaschke.de> (metaseo)
+ *  (c) 2013 Markus Blaschke (TEQneers GmbH & Co. KG) <blaschke@teqneers.de> (tq_seo)
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ */
+
+namespace Metaseo\Metaseo\Controller\Ajax\PageSeo;
+
+use Metaseo\Metaseo\Controller\Ajax\AbstractPageSeoController;
+use Metaseo\Metaseo\Controller\Ajax\PageSeoInterface;
+
+class SearchEnginesController extends AbstractPageSeoController implements PageSeoInterface
+{
+    const LIST_TYPE = 'searchengines';
+
+    /**
+     * @inheritDoc
+     */
+    protected function initFieldList()
+    {
+        $this->fieldList = array(
+            'tx_metaseo_canonicalurl',
+            'tx_metaseo_is_exclude',
+            'tx_metaseo_priority',
+        );
+    }
+}

--- a/Classes/Controller/Ajax/PageSeo/UrlController.php
+++ b/Classes/Controller/Ajax/PageSeo/UrlController.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ *  Copyright notice
+ *
+ *  (c) 2015 Markus Blaschke <typo3@markus-blaschke.de> (metaseo)
+ *  (c) 2013 Markus Blaschke (TEQneers GmbH & Co. KG) <blaschke@teqneers.de> (tq_seo)
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ */
+
+namespace Metaseo\Metaseo\Controller\Ajax\PageSeo;
+
+use Metaseo\Metaseo\Exception\Ajax\AjaxException;
+use Metaseo\Metaseo\Controller\Ajax\AbstractPageSeoController;
+use Metaseo\Metaseo\Controller\Ajax\PageSeoSimulateInterface;
+use Metaseo\Metaseo\Utility\GeneralUtility;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+class UrlController extends AbstractPageSeoController implements PageSeoSimulateInterface
+{
+    const LIST_TYPE = 'url';
+
+    /**
+     * @inheritDoc
+     */
+    protected function initFieldList()
+    {
+        $this->fieldList = array(
+            'title',
+            'url_scheme',
+            'alias',
+            'tx_realurl_pathsegment',
+            'tx_realurl_pathoverride',
+            'tx_realurl_exclude',
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function simulateAction()
+    {
+        try {
+            $this->init();
+            $ret = $this->executeSimulate();
+        } catch (AjaxException $ajaxException) {
+            return $this->ajaxErrorHandler($ajaxException);
+        }
+
+        return $this->ajaxSuccess($ret);
+    }
+
+    /**
+     * @return array
+     */
+    public function executeSimulate()
+    {
+        $pid = (int)$this->postVar['pid'];
+
+        if (empty($pid)) {
+
+            return $this->ajaxErrorTranslate(
+                'message.error.typo3_page_not_found',
+                '[0x4FBF3C0A]',
+                self::HTTP_STATUS_BAD_REQUEST
+            );
+        }
+
+        $page = BackendUtility::getRecord('pages', $pid);
+
+        if (empty($page)) {
+
+            return $this->ajaxErrorTranslate(
+                'message.error.typo3_page_not_found',
+                '[0x4FBF3C0B]',
+                self::HTTP_STATUS_BAD_REQUEST
+            );
+        }
+
+        if (ExtensionManagementUtility::isLoaded('realurl')) {
+            // Disable caching for url
+            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['enableUrlDecodeCache'] = 0;
+            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['enableUrlEncodeCache'] = 0;
+            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['disablePathCache']     = 1;
+        }
+
+        $this->initTsfe($page, null, $page, null);
+
+        $ret = $GLOBALS['TSFE']->cObj->typolink_URL(array('parameter' => $page['uid']));
+
+        if (!empty($ret)) {
+            $ret = GeneralUtility::fullUrl($ret);
+        }
+
+        if (empty($ret)) {
+
+            return $this->ajaxErrorTranslate(
+                'message.error.url_generation_failed',
+                '[0x4FBF3C01]',
+                self::HTTP_STATUS_BAD_REQUEST
+            );
+        }
+
+        return array(
+            'url' => $ret,
+        );
+    }
+}

--- a/Classes/Controller/Ajax/PageSeoInterface.php
+++ b/Classes/Controller/Ajax/PageSeoInterface.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ *  Copyright notice
+ *
+ *  (c) 2015 Markus Blaschke <typo3@markus-blaschke.de> (metaseo)
+ *  (c) 2013 Markus Blaschke (TEQneers GmbH & Co. KG) <blaschke@teqneers.de> (tq_seo)
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ */
+
+namespace Metaseo\Metaseo\Controller\Ajax;
+
+interface PageSeoInterface
+{
+    /**
+     * Executes an AJAX request which displays the data (usually as a list)
+     *
+     * @return array
+     */
+    public function indexAction();
+
+    /**
+     * Executes an AJAX request which updates the data in the database
+     *
+     * @return array
+     */
+    public function updateAction();
+
+    /**
+     * Executes an AJAX request which updates the data in the database recursively
+     *
+     * @return array
+     */
+    public function updateRecursiveAction();
+
+    /**
+     * Enables testing mode for easier data retrieval (for use in unit tests)
+     *
+     * @param boolean $returnAsArray If set to true, testing mode is enabled.
+     *
+     * @return self
+     */
+    public function setReturnAsArray($returnAsArray = true);
+}

--- a/Classes/Controller/Ajax/PageSeoSimulateInterface.php
+++ b/Classes/Controller/Ajax/PageSeoSimulateInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *  Copyright notice
+ *
+ *  (c) 2015 Markus Blaschke <typo3@markus-blaschke.de> (metaseo)
+ *  (c) 2013 Markus Blaschke (TEQneers GmbH & Co. KG) <blaschke@teqneers.de> (tq_seo)
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ */
+
+namespace Metaseo\Metaseo\Controller\Ajax;
+
+interface PageSeoSimulateInterface extends PageSeoInterface
+{
+    /**
+     * Executes an AJAX request which simulates field values
+     *
+     * @return array
+     */
+    public function simulateAction();
+}

--- a/Classes/Controller/Ajax/SitemapController.php
+++ b/Classes/Controller/Ajax/SitemapController.php
@@ -27,6 +27,7 @@
 namespace Metaseo\Metaseo\Controller\Ajax;
 
 use Metaseo\Metaseo\Controller\AbstractAjaxController;
+use Metaseo\Metaseo\Exception\Ajax\AjaxException;
 use Metaseo\Metaseo\Utility\DatabaseUtility;
 use Metaseo\Metaseo\Utility\SitemapUtility;
 
@@ -35,13 +36,32 @@ use Metaseo\Metaseo\Utility\SitemapUtility;
  */
 class SitemapController extends AbstractAjaxController
 {
+    const AJAX_PREFIX = 'tx_metaseo_controller_ajax_sitemap';
+
+    /**
+     * @return array
+     *
+     * @throws AjaxException
+     */
+    public function indexAction()
+    {
+        try {
+            $this->init();
+            $ret = $this->executeIndex();
+
+        } catch (AjaxException $ajaxException) {
+            return $this->ajaxErrorHandler($ajaxException);
+        }
+
+        return $this->ajaxSuccess($ret);
+    }
 
     /**
      * Return sitemap entry list for root tree
      *
      * @return    array
      */
-    protected function executeGetList()
+    protected function executeIndex()
     {
         // Init
         $rootPid      = (int)$this->postVar['pid'];
@@ -138,18 +158,34 @@ class SitemapController extends AbstractAjaxController
                   LIMIT ' . (int)$offset . ', ' . (int)$itemsPerPage;
         $list  = DatabaseUtility::getAll($query);
 
-        return $this->ajaxSuccess(
-            array(
+        return array(
             'results' => $itemCount,
             'rows'    => $list,
-            )
         );
+    }
+
+    /**
+     * @return array
+     *
+     * @throws AjaxException
+     */
+    public function blacklistAction()
+    {
+        try {
+            $this->init();
+            $ret = $this->executeBlacklist();
+
+        } catch (AjaxException $ajaxException) {
+            return $this->ajaxErrorHandler($ajaxException);
+        }
+
+        return $this->ajaxSuccess($ret);
     }
 
     /*
      * Blacklist sitemap entries
      *
-     * @return    boolean
+     * @return    array
      */
     protected function executeBlacklist()
     {
@@ -177,13 +213,31 @@ class SitemapController extends AbstractAjaxController
                    WHERE ' . $where;
         DatabaseUtility::exec($query);
 
-        return $this->ajaxSuccess();
+        return array();
+    }
+
+    /**
+     * @return array
+     *
+     * @throws AjaxException
+     */
+    public function whitelistAction()
+    {
+        try {
+            $this->init();
+            $ret = $this->executeWhitelist();
+
+        } catch (AjaxException $ajaxException) {
+            return $this->ajaxErrorHandler($ajaxException);
+        }
+
+        return $this->ajaxSuccess($ret);
     }
 
     /*
      * Whitelist sitemap entries
      *
-     * @return    boolean
+     * @return    array
      */
     protected function executeWhitelist()
     {
@@ -211,14 +265,31 @@ class SitemapController extends AbstractAjaxController
                    WHERE ' . $where;
         DatabaseUtility::exec($query);
 
-        return $this->ajaxSuccess();
+        return array();
     }
 
+    /**
+     * @return array
+     *
+     * @throws AjaxException
+     */
+    public function deleteAction()
+    {
+        try {
+            $this->init();
+            $ret = $this->executeDelete();
+
+        } catch (AjaxException $ajaxException) {
+            return $this->ajaxErrorHandler($ajaxException);
+        }
+
+        return $this->ajaxSuccess($ret);
+    }
 
     /**
      * Delete sitemap entries
      *
-     * @return    boolean
+     * @return    array
      */
     protected function executeDelete()
     {
@@ -245,13 +316,31 @@ class SitemapController extends AbstractAjaxController
                          WHERE ' . $where;
         DatabaseUtility::exec($query);
 
-        return $this->ajaxSuccess();
+        return array();
+    }
+
+    /**
+     * @return array
+     *
+     * @throws AjaxException
+     */
+    public function deleteAllAction()
+    {
+        try {
+            $this->init();
+            $ret = $this->executeDeleteAll();
+
+        } catch (AjaxException $ajaxException) {
+            return $this->ajaxErrorHandler($ajaxException);
+        }
+
+        return $this->ajaxSuccess($ret);
     }
 
     /**
      * Delete all sitemap entries
      *
-     * @return    boolean
+     * @return    array
      */
     protected function executeDeleteAll()
     {
@@ -274,6 +363,26 @@ class SitemapController extends AbstractAjaxController
                          WHERE ' . $where;
         DatabaseUtility::exec($query);
 
-        return $this->ajaxSuccess();
+        return array();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getAjaxPrefix()
+    {
+        return self::AJAX_PREFIX;
+    }
+
+    /**
+     * Returns array of classes which contain Ajax controllers with <ajaxPrefix> => <className)
+     *
+     * @return array
+     */
+    public static function getBackendAjaxClassNames()
+    {
+        return array(
+            self::AJAX_PREFIX => __CLASS__,
+        );
     }
 }

--- a/Classes/Controller/Ajax/SitemapController.php
+++ b/Classes/Controller/Ajax/SitemapController.php
@@ -24,15 +24,16 @@
  *  This copyright notice MUST APPEAR in all copies of the script!
  */
 
-namespace Metaseo\Metaseo\Backend\Ajax;
+namespace Metaseo\Metaseo\Controller\Ajax;
 
+use Metaseo\Metaseo\Controller\AbstractAjaxController;
 use Metaseo\Metaseo\Utility\DatabaseUtility;
 use Metaseo\Metaseo\Utility\SitemapUtility;
 
 /**
  * TYPO3 Backend ajax module sitemap
  */
-class SitemapAjax extends AbstractAjax
+class SitemapController extends AbstractAjaxController
 {
 
     /**

--- a/Classes/Controller/BackendPageSeoController.php
+++ b/Classes/Controller/BackendPageSeoController.php
@@ -27,6 +27,13 @@
 namespace Metaseo\Metaseo\Controller;
 
 use Metaseo\Metaseo\Backend\Module\AbstractStandardModule;
+use Metaseo\Metaseo\Controller\Ajax\AbstractPageSeoController;
+use Metaseo\Metaseo\Controller\Ajax\PageSeo\GeoController;
+use Metaseo\Metaseo\Controller\Ajax\PageSeo\MetaDataController;
+use Metaseo\Metaseo\Controller\Ajax\PageSeo\PageTitleController;
+use Metaseo\Metaseo\Controller\Ajax\PageSeo\PageTitleSimController;
+use Metaseo\Metaseo\Controller\Ajax\PageSeo\SearchEnginesController;
+use Metaseo\Metaseo\Controller\Ajax\PageSeo\UrlController;
 use Metaseo\Metaseo\Utility\DatabaseUtility;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Backend\Utility\IconUtility;
@@ -52,7 +59,47 @@ class BackendPageSeoController extends AbstractStandardModule
      */
     public function mainAction()
     {
-        $this->handleSubAction('metadata');
+        $this->handleSubAction(MetaDataController::LIST_TYPE);
+    }
+
+    /**
+     * Geo action
+     */
+    public function geoAction()
+    {
+        $this->handleSubAction(GeoController::LIST_TYPE);
+    }
+
+    /**
+     * searchengines action
+     */
+    public function searchenginesAction()
+    {
+        $this->handleSubAction(SearchEnginesController::LIST_TYPE);
+    }
+
+    /**
+     * url action
+     */
+    public function urlAction()
+    {
+        $this->handleSubAction(UrlController::LIST_TYPE);
+    }
+
+    /**
+     * pagetitle action
+     */
+    public function pagetitleAction()
+    {
+        $this->handleSubAction(PageTitleController::LIST_TYPE);
+    }
+
+    /**
+     * pagetitlesim action
+     */
+    public function pagetitlesimAction()
+    {
+        $this->handleSubAction(PageTitleSimController::LIST_TYPE);
     }
 
     /**
@@ -146,10 +193,15 @@ class BackendPageSeoController extends AbstractStandardModule
 
         $realUrlAvailable = ExtensionManagementUtility::isLoaded('realurl');
 
+        $ajaxController = AbstractPageSeoController::AJAX_PREFIX . $listType;
+
+        if (!array_key_exists($ajaxController, AbstractPageSeoController::getBackendAjaxClassNames())) {
+            throw new \RuntimeException('Ajax controller with this name was not registered by MetaSEO.');
+        }
 
         $metaSeoConf = array(
-            'sessionToken'     => $this->sessionToken('metaseo_metaseo_backend_ajax_pageajax'),
-            'ajaxController'   => 'tx_metaseo_backend_ajax::page',
+            'sessionToken'     => $this->sessionToken(AbstractPageSeoController::AJAX_PREFIX),
+            'ajaxController'   => $ajaxController,
             'pid'              => (int)$pageId,
             'renderTo'         => 'tx-metaseo-sitemap-grid',
             'pagingSize'       => 50,
@@ -238,45 +290,5 @@ class BackendPageSeoController extends AbstractStandardModule
             MetaSeo.overview.conf.lang = ' . json_encode($metaSeoLang) . ';
         '
         );
-    }
-
-    /**
-     * Geo action
-     */
-    public function geoAction()
-    {
-        $this->handleSubAction('geo');
-    }
-
-    /**
-     * searchengines action
-     */
-    public function searchenginesAction()
-    {
-        $this->handleSubAction('searchengines');
-    }
-
-    /**
-     * url action
-     */
-    public function urlAction()
-    {
-        $this->handleSubAction('url');
-    }
-
-    /**
-     * pagetitle action
-     */
-    public function pagetitleAction()
-    {
-        $this->handleSubAction('pagetitle');
-    }
-
-    /**
-     * pagetitle action
-     */
-    public function pagetitlesimAction()
-    {
-        $this->handleSubAction('pagetitlesim');
     }
 }

--- a/Classes/Controller/BackendSitemapController.php
+++ b/Classes/Controller/BackendSitemapController.php
@@ -27,6 +27,7 @@
 namespace Metaseo\Metaseo\Controller;
 
 use Metaseo\Metaseo\Backend\Module\AbstractStandardModule;
+use Metaseo\Metaseo\Controller\Ajax\SitemapController;
 use Metaseo\Metaseo\Utility\BackendUtility;
 use Metaseo\Metaseo\Utility\DatabaseUtility;
 use Metaseo\Metaseo\Utility\SitemapUtility;
@@ -263,8 +264,8 @@ class BackendSitemapController extends AbstractStandardModule
         // ###############################
 
         $metaSeoConf = array(
-            'sessionToken'          => $this->sessionToken('metaseo_metaseo_backend_ajax_sitemapajax'),
-            'ajaxController'        => 'tx_metaseo_backend_ajax::sitemap',
+            'sessionToken'          => $this->sessionToken(SitemapController::AJAX_PREFIX),
+            'ajaxController'        => SitemapController::AJAX_PREFIX,
             'pid'                   => (int)$rootPid,
             'renderTo'              => 'tx-metaseo-sitemap-grid',
             'pagingSize'            => 50,

--- a/Classes/Exception/Ajax/AjaxException.php
+++ b/Classes/Exception/Ajax/AjaxException.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ *  Copyright notice
+ *
+ *  (c) 2015 Markus Blaschke <typo3@markus-blaschke.de> (metaseo)
+ *  (c) 2013 Markus Blaschke (TEQneers GmbH & Co. KG) <blaschke@teqneers.de> (tq_seo)
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ */
+
+namespace Metaseo\Metaseo\Exception\Ajax;
+
+use Exception;
+
+class AjaxException extends Exception
+{
+    /**
+     * @var string
+     */
+    protected $message;
+
+    /**
+     * @var string
+     */
+    protected $code;
+
+    /**
+     * @var int
+     */
+    protected $httpStatus;
+
+    /**
+     * @param string $message
+     * @param string $code
+     * @param int    $httpStatus
+     */
+    public function __construct($message = '', $code = '', $httpStatus = 500)
+    {
+        parent::__construct();
+        $this->message = $message;
+        $this->code = $code;
+        $this->httpStatus = $httpStatus;
+    }
+
+    public function getHttpStatus()
+    {
+        return $this->httpStatus;
+    }
+}

--- a/Classes/Utility/BackendUtility.php
+++ b/Classes/Utility/BackendUtility.php
@@ -26,8 +26,8 @@
 
 namespace Metaseo\Metaseo\Utility;
 
-use TYPO3\CMS\Core\Utility\GeneralUtility as Typo3GeneralUtility;
-use TYPO3\CMS\Backend\Routing\UriBuilder;
+//use TYPO3\CMS\Core\Utility\GeneralUtility as Typo3GeneralUtility; //for code in comments. don't remove.
+//use TYPO3\CMS\Backend\Routing\UriBuilder; //for code in comments. don't remove.
 
 /**
  * Backend utility
@@ -80,42 +80,42 @@ class BackendUtility
         return $cache;
     }
 
-    /**
-     * Returns the Ajax URL for a given AjaxID including a CSRF token.
-     *
-     * This function is mostly copied from the core, because it should not be used directly.
-     * You need to test it at first usage in this project and eventually use the latest version from the core.
-     * See #147 to learn about TYPO3's deprecation concept and our refactoring concept.
-     *
-     * Ajax URLs of all registered backend Ajax handlers are automatically published
-     * to JavaScript inline settings: TYPO3.settings.ajaxUrls['ajaxId']
-     *
-     * @param string $ajaxIdentifier Identifier of the AJAX callback
-     * @param array $urlParameters URL parameters that should be added as key value pairs
-     * @param bool $returnAbsoluteUrl If set to TRUE, the URL returned will be absolute,
-     *                                $backPathOverride will be ignored in this case
-     *
-     * @return string Calculated URL
-     * @internal
-     */
-    public static function getAjaxUrl(
-        $ajaxIdentifier,
-        array $urlParameters = array(),
-        $returnAbsoluteUrl = false
-    ) {
-        return self::getUriBuilder()
-            ->buildUriFromAjaxId(
-                $ajaxIdentifier,
-                $urlParameters,
-                $returnAbsoluteUrl ? UriBuilder::ABSOLUTE_URL : UriBuilder::ABSOLUTE_PATH
-            );
-    }
+    //    /**
+    //     * Returns the Ajax URL for a given AjaxID including a CSRF token.
+    //     *
+    //     * This function is mostly copied from the core, because it should not be used directly. Usable at ~7.4+
+    //     * You need to test it at first usage in this project and eventually use the latest version from the core.
+    //     * See #147 to learn about TYPO3's deprecation concept and our refactoring concept.
+    //     *
+    //     * Ajax URLs of all registered backend Ajax handlers are automatically published
+    //     * to JavaScript inline settings: TYPO3.settings.ajaxUrls['ajaxId']
+    //     *
+    //     * @param string $ajaxIdentifier Identifier of the AJAX callback
+    //     * @param array $urlParameters URL parameters that should be added as key value pairs
+    //     * @param bool $returnAbsoluteUrl If set to TRUE, the URL returned will be absolute,
+    //     *                                $backPathOverride will be ignored in this case
+    //     *
+    //     * @return string Calculated URL
+    //     * @internal
+    //     */
+    //    public static function getAjaxUrl(
+    //        $ajaxIdentifier,
+    //        array $urlParameters = array(),
+    //        $returnAbsoluteUrl = false
+    //    ) {
+    //        return self::getUriBuilder()
+    //            ->buildUriFromAjaxId(
+    //                $ajaxIdentifier,
+    //                $urlParameters,
+    //                $returnAbsoluteUrl ? UriBuilder::ABSOLUTE_URL : UriBuilder::ABSOLUTE_PATH
+    //            );
+    //    }
 
-    /**
-     * @return UriBuilder
-     */
-    public static function getUriBuilder()
-    {
-        return Typo3GeneralUtility::makeInstance('\\TYPO3\\CMS\\Backend\\Routing\\UriBuilder');
-    }
+    //    /**
+    //     * @return UriBuilder
+    //     */
+    //    public static function getUriBuilder()
+    //    {
+    //        return Typo3GeneralUtility::makeInstance('\\TYPO3\\CMS\\Backend\\Routing\\UriBuilder');
+    //    }
 }

--- a/Classes/Utility/ExtensionManagementUtility.php
+++ b/Classes/Utility/ExtensionManagementUtility.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ *  Copyright notice
+ *
+ *  (c) 2015 Markus Blaschke <typo3@markus-blaschke.de> (metaseo)
+ *  (c) 2013 Markus Blaschke (TEQneers GmbH & Co. KG) <blaschke@teqneers.de> (tq_seo)
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ */
+
+namespace Metaseo\Metaseo\Utility;
+
+use ReflectionMethod;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility as Typo3ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility as Typo3GeneralUtility;
+
+class ExtensionManagementUtility
+{
+    const AJAX_METHOD_NAME_SUFFIX = 'Action';
+    const AJAX_METHOD_DELIMITER = '::';
+
+    /**
+     * Registers all public methods of a specified class with method name suffix 'Action' as ajax actions
+     * The ajax method names have the form <ajaxPrefix>::<ajaxMethod> (with 'Action' removed from the method)
+     * or <ajaxMethod> for empty/unspecified <ajaxPrefix>
+     *
+     * @param string $qualifiedClassName
+     * @param string $ajaxPrefix
+     */
+    public static function registerAjaxClass($qualifiedClassName, $ajaxPrefix = '')
+    {
+        if (!empty($ajaxPrefix)) {
+            $ajaxPrefix = $ajaxPrefix . self::AJAX_METHOD_DELIMITER;
+        }
+        self::removeBeginningBackslash($qualifiedClassName);
+        $reflectionClass = self::getReflectionClass($qualifiedClassName);
+        $methods = $reflectionClass->getMethods(ReflectionMethod::IS_PUBLIC);
+        foreach ($methods as $method) {
+            $methodName = $method->getName();
+            if (self::isAjaxMethod($methodName)) {
+                $ajaxMethodName = self::extractAjaxMethod($methodName);
+                Typo3ExtensionManagementUtility::registerAjaxHandler(
+                    $ajaxPrefix . $ajaxMethodName,
+                    $qualifiedClassName . '->' . $methodName
+                );
+            }
+        }
+    }
+
+    /**
+     * @param array $qualifiedClassNames
+     */
+    public static function registerAjaxClasses(array $qualifiedClassNames)
+    {
+        foreach ($qualifiedClassNames as $ajaxPrefix => $qualifiedClassName) {
+            self::registerAjaxClass($qualifiedClassName, $ajaxPrefix);
+        }
+    }
+
+    /**
+     * @param string $methodName
+     *
+     * @return bool
+     */
+    protected static function isAjaxMethod($methodName)
+    {
+        $suffixLength = strlen(self::AJAX_METHOD_NAME_SUFFIX);
+
+        return strlen($methodName) > $suffixLength
+            && self::AJAX_METHOD_NAME_SUFFIX === substr($methodName, -1 * $suffixLength);
+    }
+
+    /**
+     * @param string $methodName
+     *
+     * @return string
+     */
+    protected static function extractAjaxMethod($methodName)
+    {
+        $suffixLength = strlen(self::AJAX_METHOD_NAME_SUFFIX);
+
+        return substr(
+            $methodName,
+            0,
+            strlen($methodName) - $suffixLength
+        );
+    }
+
+    /**
+     * @param $qualifiedClassName
+     */
+    protected static function removeBeginningBackslash(&$qualifiedClassName)
+    {
+        if ($qualifiedClassName[0] === '\\') {
+            $qualifiedClassName = substr($qualifiedClassName, 1);
+        }
+    }
+
+    /**
+     * @param $qualifiedClassName
+     *
+     * @return \ReflectionClass
+     */
+    protected static function getReflectionClass($qualifiedClassName)
+    {
+        return Typo3GeneralUtility::makeInstance('ReflectionClass', $qualifiedClassName);
+    }
+}

--- a/Resources/Public/Backend/JavaScript/MetaSeo.overview.js
+++ b/Resources/Public/Backend/JavaScript/MetaSeo.overview.js
@@ -312,7 +312,7 @@ MetaSeo.overview.grid = {
                                         grid.getStore().load();
                                     };
 
-                                    var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.overview.conf.ajaxController] + '&cmd=updatePageFieldRecursively';
+                                    var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.overview.conf.ajaxController + '::updateRecursive'];
 
                                     Ext.Ajax.request({
                                         url: ajaxUrl,
@@ -350,7 +350,7 @@ MetaSeo.overview.grid = {
                                         grid.getStore().load();
                                     };
 
-                                    var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.overview.conf.ajaxController] + '&cmd=updatePageField';
+                                    var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.overview.conf.ajaxController + '::update'];
 
                                     Ext.Ajax.request({
                                         url: ajaxUrl,
@@ -475,7 +475,7 @@ MetaSeo.overview.grid = {
                 break;
         }
 
-        var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.overview.conf.ajaxController] + '&cmd=getList';
+        var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.overview.conf.ajaxController + '::index'];
 
         return new Ext.data.Store({
             storeId: 'MetaSeoOverviewRecordsStore',
@@ -926,7 +926,7 @@ MetaSeo.overview.grid = {
                                 }
                             };
 
-                            var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.overview.conf.ajaxController] + '&cmd=generateSimulatedUrl';
+                            var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.overview.conf.ajaxController + '::simulate'];
 
                             Ext.Ajax.request({
                                 url: ajaxUrl,
@@ -1013,8 +1013,7 @@ MetaSeo.overview.grid = {
                                 TYPO3.Flashmessage.display(TYPO3.Severity.information, '', Ext.util.Format.htmlEncode(response.title));
                             }
                         };
-
-                        var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.overview.conf.ajaxController] + '&cmd=generateSimulatedTitle';
+                        var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.overview.conf.ajaxController + '::simulate'];
 
                         Ext.Ajax.request({
                             url: ajaxUrl,

--- a/Resources/Public/Backend/JavaScript/MetaSeo.sitemap.js
+++ b/Resources/Public/Backend/JavaScript/MetaSeo.sitemap.js
@@ -38,7 +38,7 @@ MetaSeo.sitemap.grid = {
          * grid storage
          ****************************************************/
 
-        var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.sitemap.conf.ajaxController] + '&cmd=getList';
+        var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.sitemap.conf.ajaxController + '::index'];
 
         var gridDs = new Ext.data.Store({
             storeId: 'MetaSeoSitemapRecordsStore',
@@ -124,7 +124,7 @@ MetaSeo.sitemap.grid = {
         };
 
         var function_delete_all = function (ob) {
-            var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.sitemap.conf.ajaxController] + '&cmd=deleteAll';
+            var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.sitemap.conf.ajaxController + '::deleteAll'];
 
             var frmConfirm = new Ext.Window({
                 xtype: 'form',
@@ -179,7 +179,7 @@ MetaSeo.sitemap.grid = {
 
         var rowAction = function (ob, cmd, confirmTitle, confirmText) {
             var recList = grid.getSelectionModel().getSelections();
-            var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.sitemap.conf.ajaxController] + '&cmd=' + cmd;
+            var ajaxUrl = TYPO3.settings.ajaxUrls[MetaSeo.sitemap.conf.ajaxController + '::' + cmd];
 
             if (recList.length >= 1) {
                 var uidList = [];

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -84,12 +84,12 @@ if (TYPO3_MODE == 'BE') {
     // AJAX
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerAjaxHandler(
         'tx_metaseo_backend_ajax::sitemap',
-        'Metaseo\\Metaseo\\Backend\\Ajax\SitemapAjax->main'
+        'Metaseo\\Metaseo\\Controller\\Ajax\\SitemapController->main'
     );
 
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerAjaxHandler(
         'tx_metaseo_backend_ajax::page',
-        'Metaseo\\Metaseo\\Backend\\Ajax\PageAjax->main'
+        'Metaseo\\Metaseo\\Controller\\Ajax\\AbstractPageSeoController->main'
     );
 }
 

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -81,15 +81,15 @@ if (TYPO3_MODE == 'BE') {
         )
     );
 
+    // ############################################################################
+    // REGISTER AJAX CONTROLLERS
+    // ############################################################################
     // AJAX
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerAjaxHandler(
-        'tx_metaseo_backend_ajax::sitemap',
-        'Metaseo\\Metaseo\\Controller\\Ajax\\SitemapController->main'
+    \Metaseo\Metaseo\Utility\ExtensionManagementUtility::registerAjaxClasses(
+        \Metaseo\Metaseo\Controller\Ajax\AbstractPageSeoController::getBackendAjaxClassNames()
     );
-
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerAjaxHandler(
-        'tx_metaseo_backend_ajax::page',
-        'Metaseo\\Metaseo\\Controller\\Ajax\\AbstractPageSeoController->main'
+    \Metaseo\Metaseo\Utility\ExtensionManagementUtility::registerAjaxClasses(
+        \Metaseo\Metaseo\Controller\Ajax\SitemapController::getBackendAjaxClassNames()
     );
 }
 


### PR DESCRIPTION
[TASK] OOP: Refactor Ajax controllers

* OOP: Use Subclasses for PageSeo Ajax Controllers #160 
* ExceptionHandler in Ajax Methods #161
* Use constants for Ajax controller names #159
* Use reflections to determine Ajax actions #155
* Unregister advanced Ajax controller #158
* Move Ajax classes to Controller namespace #156
    
Fixes #160
Fixes #159
Fixes #158
Fixes #161
Fixes #155
Fixes #156
