### PR TITLE
Removes obsolete CSRF protection and makes use of core's PSR-7

### DIFF
--- a/Classes/Controller/Ajax/AbstractPageSeoController.php
+++ b/Classes/Controller/Ajax/AbstractPageSeoController.php
@@ -608,7 +608,7 @@ abstract class AbstractPageSeoController extends AbstractAjaxController implemen
                 // UPDATE
                 // ################
 
-                $this->tce()->updateDB(
+                $this->getTce()->updateDB(
                     'pages_language_overlay',
                     (int)$overlayId,
                     array(
@@ -618,7 +618,7 @@ abstract class AbstractPageSeoController extends AbstractAjaxController implemen
                 break;
             case 'pages':
                 // Update field in page (also logs update event and clear cache for this page)
-                $this->tce()->updateDB(
+                $this->getTce()->updateDB(
                     'pages',
                     (int)$pid,
                     array(

--- a/Classes/Controller/Ajax/AbstractPageSeoController.php
+++ b/Classes/Controller/Ajax/AbstractPageSeoController.php
@@ -38,6 +38,7 @@ use Metaseo\Metaseo\Exception\Ajax\AjaxException;
 use Metaseo\Metaseo\Utility\DatabaseUtility;
 use Metaseo\Metaseo\Utility\FrontendUtility;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Http\AjaxRequestHandler;
 
 /**
  * TYPO3 Backend ajax module page
@@ -79,16 +80,17 @@ abstract class AbstractPageSeoController extends AbstractAjaxController implemen
     /**
      * @inheritDoc
      */
-    public function indexAction()
+    public function indexAction($params = array(), AjaxRequestHandler &$ajaxObj = null)
     {
         try {
             $this->init();
-            $ret = $this->executeIndex();
-        } catch (AjaxException $ajaxException) {
-            return $this->ajaxExceptionHandler($ajaxException);
+            $ajaxObj->setContent($this->executeIndex());
+        } catch (\Exception $exception) {
+            $this->ajaxExceptionHandler($exception, $ajaxObj);
         }
 
-        return $this->ajaxSuccess($ret);
+        $ajaxObj->setContentFormat(self::CONTENT_FORMAT_JSON);
+        $ajaxObj->render();
     }
 
     /**
@@ -368,17 +370,17 @@ abstract class AbstractPageSeoController extends AbstractAjaxController implemen
     /**
      * @inheritDoc
      */
-    public function updateAction()
+    public function updateAction($params = array(), AjaxRequestHandler &$ajaxObj = null)
     {
         try {
             $this->init();
-            $ret = $this->executeUpdate();
-
-        } catch (AjaxException $ajaxException) {
-            return $this->ajaxExceptionHandler($ajaxException);
+            $ajaxObj->setContent($this->executeUpdate());
+        } catch (\Exception $exception) {
+            $this->ajaxExceptionHandler($exception, $ajaxObj);
         }
 
-        return $this->ajaxSuccess($ret);
+        $ajaxObj->setContentFormat(self::CONTENT_FORMAT_JSON);
+        $ajaxObj->render();
     }
 
     /**
@@ -512,16 +514,17 @@ abstract class AbstractPageSeoController extends AbstractAjaxController implemen
     /**
      * @inheritDoc
      */
-    public function updateRecursiveAction()
+    public function updateRecursiveAction($params = array(), AjaxRequestHandler &$ajaxObj = null)
     {
         try {
             $this->init();
-            $ret = $this->executeUpdateRecursive();
-        } catch (AjaxException $ajaxException) {
-            return $this->ajaxExceptionHandler($ajaxException);
+            $ajaxObj->setContent($this->executeUpdateRecursive());
+        } catch (\Exception $exception) {
+            $this->ajaxExceptionHandler($exception, $ajaxObj);
         }
 
-        return $this->ajaxSuccess($ret);
+        $ajaxObj->setContentFormat(self::CONTENT_FORMAT_JSON);
+        $ajaxObj->render();
     }
 
     /**

--- a/Classes/Controller/Ajax/PageSeo/PageTitleSimController.php
+++ b/Classes/Controller/Ajax/PageSeo/PageTitleSimController.php
@@ -31,6 +31,7 @@ use Metaseo\Metaseo\Controller\Ajax\PageSeoSimulateInterface;
 use Metaseo\Metaseo\Exception\Ajax\AjaxException;
 use Metaseo\Metaseo\Utility\DatabaseUtility;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Http\AjaxRequestHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility as Typo3GeneralUtility;
 
 class PageTitleSimController extends AbstractPageSeoController implements PageSeoSimulateInterface
@@ -104,16 +105,17 @@ class PageTitleSimController extends AbstractPageSeoController implements PageSe
     /**
      * @inheritDoc
      */
-    public function simulateAction()
+    public function simulateAction($params = array(), AjaxRequestHandler &$ajaxObj = null)
     {
         try {
             $this->init();
-            $ret = $this->executeSimulate();
-        } catch (AjaxException $ajaxException) {
-            return $this->ajaxExceptionHandler($ajaxException);
+            $ajaxObj->setContent($this->executeSimulate());
+        } catch (\Exception $exception) {
+            $this->ajaxExceptionHandler($exception, $ajaxObj);
         }
 
-        return $this->ajaxSuccess($ret);
+        $ajaxObj->setContentFormat(self::CONTENT_FORMAT_JSON);
+        $ajaxObj->render();
     }
 
     /**

--- a/Classes/Controller/Ajax/PageSeo/UrlController.php
+++ b/Classes/Controller/Ajax/PageSeo/UrlController.php
@@ -31,6 +31,7 @@ use Metaseo\Metaseo\Controller\Ajax\PageSeoSimulateInterface;
 use Metaseo\Metaseo\Exception\Ajax\AjaxException;
 use Metaseo\Metaseo\Utility\GeneralUtility;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Http\AjaxRequestHandler;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
 class UrlController extends AbstractPageSeoController implements PageSeoSimulateInterface
@@ -55,16 +56,17 @@ class UrlController extends AbstractPageSeoController implements PageSeoSimulate
     /**
      * @inheritDoc
      */
-    public function simulateAction()
+    public function simulateAction($params = array(), AjaxRequestHandler &$ajaxObj = null)
     {
         try {
             $this->init();
-            $ret = $this->executeSimulate();
-        } catch (AjaxException $ajaxException) {
-            return $this->ajaxExceptionHandler($ajaxException);
+            $ajaxObj->setContent($this->executeSimulate());
+        } catch (\Exception $exception) {
+            $this->ajaxExceptionHandler($exception, $ajaxObj);
         }
 
-        return $this->ajaxSuccess($ret);
+        $ajaxObj->setContentFormat(self::CONTENT_FORMAT_JSON);
+        $ajaxObj->render();
     }
 
     /**

--- a/Classes/Controller/Ajax/PageSeoInterface.php
+++ b/Classes/Controller/Ajax/PageSeoInterface.php
@@ -26,35 +26,44 @@
 
 namespace Metaseo\Metaseo\Controller\Ajax;
 
+use TYPO3\CMS\Core\Http\AjaxRequestHandler;
+
 interface PageSeoInterface
 {
     /**
      * Executes an AJAX request which displays the data (usually as a list)
      *
-     * @return array
+     * @param array $params Array of parameters from the AJAX interface, currently unused (as of 6.2.14)
+     *                      becomes available starting with 7.4.0 (c048cede,
+     *                      https://forge.typo3.org/issues/68186)
+     * @param AjaxRequestHandler $ajaxObj Object of type AjaxRequestHandler
+     *
+     * @return void
      */
-    public function indexAction();
+    public function indexAction($params = array(), AjaxRequestHandler &$ajaxObj = null);
 
     /**
      * Executes an AJAX request which updates the data in the database
      *
-     * @return array
+     * @param array $params Array of parameters from the AJAX interface, currently unused (as of 6.2.14)
+     *                      becomes available starting with 7.4.0 (c048cede,
+     *                      https://forge.typo3.org/issues/68186)
+     * @param AjaxRequestHandler $ajaxObj Object of type AjaxRequestHandler
+     *
+     * @return void
      */
-    public function updateAction();
+    public function updateAction($params = array(), AjaxRequestHandler &$ajaxObj = null);
+
 
     /**
      * Executes an AJAX request which updates the data in the database recursively
      *
-     * @return array
-     */
-    public function updateRecursiveAction();
-
-    /**
-     * Enables testing mode for easier data retrieval (for use in unit tests)
+     * @param array $params Array of parameters from the AJAX interface, currently unused (as of 6.2.14)
+     *                      becomes available starting with 7.4.0 (c048cede,
+     *                      https://forge.typo3.org/issues/68186)
+     * @param AjaxRequestHandler $ajaxObj Object of type AjaxRequestHandler
      *
-     * @param boolean $returnAsArray If set to true, testing mode is enabled.
-     *
-     * @return self
+     * @return void
      */
-    public function setReturnAsArray($returnAsArray = true);
+    public function updateRecursiveAction($params = array(), AjaxRequestHandler &$ajaxObj = null);
 }

--- a/Classes/Controller/Ajax/PageSeoSimulateInterface.php
+++ b/Classes/Controller/Ajax/PageSeoSimulateInterface.php
@@ -26,12 +26,19 @@
 
 namespace Metaseo\Metaseo\Controller\Ajax;
 
+use TYPO3\CMS\Core\Http\AjaxRequestHandler;
+
 interface PageSeoSimulateInterface extends PageSeoInterface
 {
     /**
      * Executes an AJAX request which simulates field values
      *
-     * @return array
+     * @param array $params Array of parameters from the AJAX interface, currently unused (as of 6.2.14)
+     *                      becomes available starting with 7.4.0 (c048cede,
+     *                      https://forge.typo3.org/issues/68186)
+     * @param AjaxRequestHandler $ajaxObj Object of type AjaxRequestHandler
+     *
+     * @return void
      */
-    public function simulateAction();
+    public function simulateAction($params = array(), AjaxRequestHandler &$ajaxObj = null);
 }

--- a/Classes/Controller/Ajax/SitemapController.php
+++ b/Classes/Controller/Ajax/SitemapController.php
@@ -30,6 +30,7 @@ use Metaseo\Metaseo\Controller\AbstractAjaxController;
 use Metaseo\Metaseo\Exception\Ajax\AjaxException;
 use Metaseo\Metaseo\Utility\DatabaseUtility;
 use Metaseo\Metaseo\Utility\SitemapUtility;
+use TYPO3\CMS\Core\Http\AjaxRequestHandler;
 
 /**
  * TYPO3 Backend ajax module sitemap
@@ -43,17 +44,17 @@ class SitemapController extends AbstractAjaxController
      *
      * @throws AjaxException
      */
-    public function indexAction()
+    public function indexAction($params = array(), AjaxRequestHandler &$ajaxObj = null)
     {
         try {
             $this->init();
-            $ret = $this->executeIndex();
-
-        } catch (AjaxException $ajaxException) {
-            return $this->ajaxExceptionHandler($ajaxException);
+            $ajaxObj->setContent($this->executeIndex());
+        } catch (\Exception $exception) {
+            $this->ajaxExceptionHandler($exception, $ajaxObj);
         }
 
-        return $this->ajaxSuccess($ret);
+        $ajaxObj->setContentFormat(self::CONTENT_FORMAT_JSON);
+        $ajaxObj->render();
     }
 
     /**
@@ -169,17 +170,17 @@ class SitemapController extends AbstractAjaxController
      *
      * @throws AjaxException
      */
-    public function blacklistAction()
+    public function blacklistAction($params = array(), AjaxRequestHandler &$ajaxObj = null)
     {
         try {
             $this->init();
-            $ret = $this->executeBlacklist();
-
-        } catch (AjaxException $ajaxException) {
-            return $this->ajaxExceptionHandler($ajaxException);
+            $ajaxObj->setContent($this->executeBlacklist());
+        } catch (\Exception $exception) {
+            $this->ajaxExceptionHandler($exception, $ajaxObj);
         }
 
-        return $this->ajaxSuccess($ret);
+        $ajaxObj->setContentFormat(self::CONTENT_FORMAT_JSON);
+        $ajaxObj->render();
     }
 
     /*
@@ -223,17 +224,17 @@ class SitemapController extends AbstractAjaxController
      *
      * @throws AjaxException
      */
-    public function whitelistAction()
+    public function whitelistAction($params = array(), AjaxRequestHandler &$ajaxObj = null)
     {
         try {
             $this->init();
-            $ret = $this->executeWhitelist();
-
-        } catch (AjaxException $ajaxException) {
-            return $this->ajaxExceptionHandler($ajaxException);
+            $ajaxObj->setContent($this->executeWhitelist());
+        } catch (\Exception $exception) {
+            $this->ajaxExceptionHandler($exception, $ajaxObj);
         }
 
-        return $this->ajaxSuccess($ret);
+        $ajaxObj->setContentFormat(self::CONTENT_FORMAT_JSON);
+        $ajaxObj->render();
     }
 
     /*
@@ -277,17 +278,17 @@ class SitemapController extends AbstractAjaxController
      *
      * @throws AjaxException
      */
-    public function deleteAction()
+    public function deleteAction($params = array(), AjaxRequestHandler &$ajaxObj = null)
     {
         try {
             $this->init();
-            $ret = $this->executeDelete();
-
-        } catch (AjaxException $ajaxException) {
-            return $this->ajaxExceptionHandler($ajaxException);
+            $ajaxObj->setContent($this->executeDelete());
+        } catch (\Exception $exception) {
+            $this->ajaxExceptionHandler($exception, $ajaxObj);
         }
 
-        return $this->ajaxSuccess($ret);
+        $ajaxObj->setContentFormat(self::CONTENT_FORMAT_JSON);
+        $ajaxObj->render();
     }
 
     /**
@@ -330,17 +331,17 @@ class SitemapController extends AbstractAjaxController
      *
      * @throws AjaxException
      */
-    public function deleteAllAction()
+    public function deleteAllAction($params = array(), AjaxRequestHandler &$ajaxObj = null)
     {
         try {
             $this->init();
-            $ret = $this->executeDeleteAll();
-
-        } catch (AjaxException $ajaxException) {
-            return $this->ajaxExceptionHandler($ajaxException);
+            $ajaxObj->setContent($this->executeDeleteAll());
+        } catch (\Exception $exception) {
+            $this->ajaxExceptionHandler($exception, $ajaxObj);
         }
 
-        return $this->ajaxSuccess($ret);
+        $ajaxObj->setContentFormat(self::CONTENT_FORMAT_JSON);
+        $ajaxObj->render();
     }
 
     /**

--- a/Classes/Controller/BackendPageSeoController.php
+++ b/Classes/Controller/BackendPageSeoController.php
@@ -200,7 +200,6 @@ class BackendPageSeoController extends AbstractStandardModule
         }
 
         $metaSeoConf = array(
-            'sessionToken'     => $this->sessionToken(AbstractPageSeoController::AJAX_PREFIX),
             'ajaxController'   => $ajaxController,
             'pid'              => (int)$pageId,
             'renderTo'         => 'tx-metaseo-sitemap-grid',

--- a/Classes/Controller/BackendSitemapController.php
+++ b/Classes/Controller/BackendSitemapController.php
@@ -264,7 +264,6 @@ class BackendSitemapController extends AbstractStandardModule
         // ###############################
 
         $metaSeoConf = array(
-            'sessionToken'          => $this->sessionToken(SitemapController::AJAX_PREFIX),
             'ajaxController'        => SitemapController::AJAX_PREFIX,
             'pid'                   => (int)$rootPid,
             'renderTo'              => 'tx-metaseo-sitemap-grid',

--- a/Resources/Public/Backend/JavaScript/MetaSeo.overview.js
+++ b/Resources/Public/Backend/JavaScript/MetaSeo.overview.js
@@ -321,8 +321,7 @@ MetaSeo.overview.grid = {
                                             field           : Ext.encode(fieldName),
                                             value           : Ext.encode(fieldValue),
                                             sysLanguage     : Ext.encode( MetaSeo.overview.conf.sysLanguage ),
-                                            mode            : Ext.encode( MetaSeo.overview.conf.listType ),
-                                            sessionToken    : Ext.encode( MetaSeo.overview.conf.sessionToken )
+                                            mode            : Ext.encode( MetaSeo.overview.conf.listType )
                                         },
                                         success: callbackFinish,
                                         failure: callbackFinish
@@ -359,8 +358,7 @@ MetaSeo.overview.grid = {
                                             field: Ext.encode(fieldName),
                                             value: Ext.encode(fieldValue),
                                             sysLanguage: Ext.encode(MetaSeo.overview.conf.sysLanguage),
-                                            mode: Ext.encode(MetaSeo.overview.conf.listType),
-                                            sessionToken: Ext.encode(MetaSeo.overview.conf.sessionToken)
+                                            mode: Ext.encode(MetaSeo.overview.conf.listType)
                                         },
                                         success: callbackFinish,
                                         failure: callbackFinish
@@ -499,7 +497,6 @@ MetaSeo.overview.grid = {
                 sortField: Ext.encode(MetaSeo.overview.conf.sortField),
                 depth: Ext.encode(MetaSeo.overview.conf.depth),
                 listType: Ext.encode(MetaSeo.overview.conf.listType),
-                sessionToken: Ext.encode(MetaSeo.overview.conf.sessionToken),
                 sysLanguage: Ext.encode(MetaSeo.overview.conf.sysLanguage)
             },
             listeners: {
@@ -931,8 +928,7 @@ MetaSeo.overview.grid = {
                             Ext.Ajax.request({
                                 url: ajaxUrl,
                                 params: {
-                                    pid: Ext.encode(record.get('uid')),
-                                    sessionToken: Ext.encode(MetaSeo.overview.conf.sessionToken)
+                                    pid: Ext.encode(record.get('uid'))
                                 },
                                 success: callbackFinish,
                                 failure: callbackFinish
@@ -1018,8 +1014,7 @@ MetaSeo.overview.grid = {
                         Ext.Ajax.request({
                             url: ajaxUrl,
                             params: {
-                                pid: Ext.encode(record.get('uid')),
-                                sessionToken: Ext.encode(MetaSeo.overview.conf.sessionToken)
+                                pid: Ext.encode(record.get('uid'))
                             },
                             success: callbackFinish,
                             failure: callbackFinish

--- a/Resources/Public/Backend/JavaScript/MetaSeo.sitemap.js
+++ b/Resources/Public/Backend/JavaScript/MetaSeo.sitemap.js
@@ -77,8 +77,7 @@ MetaSeo.sitemap.grid = {
                 criteriaPageUid: Ext.encode(MetaSeo.sitemap.conf.criteriaPageUid),
                 criteriaPageLanguage: Ext.encode(MetaSeo.sitemap.conf.criteriaPageLanguage),
                 criteriaPageDepth: Ext.encode(MetaSeo.sitemap.conf.criteriaPageDepth),
-                criteriaIsBlacklisted: Ext.encode(MetaSeo.sitemap.conf.criteriaIsBlacklisted),
-                sessionToken: Ext.encode(MetaSeo.sitemap.conf.sessionToken)
+                criteriaIsBlacklisted: Ext.encode(MetaSeo.sitemap.conf.criteriaIsBlacklisted)
             },
             listeners: {
                 beforeload: function () {
@@ -145,8 +144,7 @@ MetaSeo.sitemap.grid = {
                             Ext.Ajax.request({
                                 url: ajaxUrl,
                                 params: {
-                                    'pid': MetaSeo.sitemap.conf.pid,
-                                    sessionToken: Ext.encode(MetaSeo.sitemap.conf.sessionToken)
+                                    'pid': MetaSeo.sitemap.conf.pid
                                 },
                                 success: function (response) {
                                     // reload the records and the table selector
@@ -206,8 +204,7 @@ MetaSeo.sitemap.grid = {
                                     url: ajaxUrl,
                                     params: {
                                         'uidList': Ext.encode(uidList),
-                                        'pid': MetaSeo.sitemap.conf.pid,
-                                        sessionToken: Ext.encode(MetaSeo.sitemap.conf.sessionToken)
+                                        'pid': MetaSeo.sitemap.conf.pid
                                     },
                                     success: function (response) {
                                         // reload the records and the table selector

--- a/Tests/Unit/Controller/Ajax/PageSeo/MetaDataControllerTest.php
+++ b/Tests/Unit/Controller/Ajax/PageSeo/MetaDataControllerTest.php
@@ -26,56 +26,83 @@
 
 namespace Metaseo\Metaseo\Tests\Unit\Controller\Ajax\PageSeo;
 
-use Metaseo\Metaseo\Controller\AbstractAjaxController;
 use Metaseo\Metaseo\Controller\Ajax\PageSeo\MetaDataController;
-use Metaseo\Metaseo\Exception\Ajax\AjaxException;
 use TYPO3\CMS\Core\Tests\UnitTestCase;
 
 class MetaDataControllerTest extends UnitTestCase
 {
     /**
-     * @expectedException \TYPO3\CMS\Core\Error\Exception
+     * @test
      */
-    public function testMissingBackendSession()
-    {
-        $this->setGlobals();
-        $subject = new MetaDataController();
-        $subject
-            ->setReturnAsArray()
-            ->indexAction();
-    }
-
-    /**
-     * @expectedException \Metaseo\Metaseo\Exception\Ajax\AjaxException
-     */
-    public function testIndexMissingSessionToken()
+    public function testIndex()
     {
         $this->setGlobals();
         $this->loginBackendUser();
+        $ajaxRequestHandler = $this->getAjaxRequestHandlerMock();
+        $ajaxRequestHandler
+            ->expects($this->exactly(1))
+            ->method('setContentFormat');
+        $ajaxRequestHandler
+            ->expects($this->exactly(1))
+            ->method('setContent');
+
         $subject = new MetaDataController();
-        try {
-            $subject
-                ->setObjectManager($this->getObjectManagerMock())
-                ->setFormProtection($this->getFormProtectionMock());
+        $subject
+            ->setObjectManager($this->getObjectManagerMock());
+        $subject
+            ->indexAction(array(), $ajaxRequestHandler);
+    }
 
-            /*
-             @todo We use 'exit' in the code which is a bad idea when dealing with unit test.
-            $subject
-                ->indexAction();
-            $this->assertTrue($this->hasOutput());
-            $jsonOutput = $this->getActualOutput();
-            $jsonArray = json_decode($jsonOutput);
-            $this->assertArrayHasKey('error', $jsonArray);
-            */
+    /**
+     * @test
+     */
+    public function testUpdate()
+    {
+        $this->setGlobals();
+        $this->loginBackendUser();
+        $ajaxRequestHandler = $this->getAjaxRequestHandlerMock();
+        $ajaxRequestHandler
+            ->expects($this->exactly(1))
+            ->method('setContentFormat');
+        $ajaxRequestHandler
+            ->expects($this->exactly(1))
+            ->method('setContent');
 
-            $subject
-                ->setReturnAsArray(true) //passes exception through for testing
-                ->indexAction();
-        } catch (AjaxException $ajaxException) {
-            $this->assertEquals('[0x4FBF3C06]', $ajaxException->getCode());
-            $this->assertEquals(AbstractAjaxController::HTTP_STATUS_UNAUTHORIZED, $ajaxException->getHttpStatus());
-            throw $ajaxException;
-        }
+        $subject = new MetaDataController();
+        $subject
+            ->setObjectManager($this->getObjectManagerMock());
+        $subject
+            ->updateAction(array(), $ajaxRequestHandler);
+    }
+
+    /**
+     * @test
+     */
+    public function testUpdateRecursive()
+    {
+        $this->setGlobals();
+        $this->loginBackendUser();
+        $ajaxRequestHandler = $this->getAjaxRequestHandlerMock();
+        $ajaxRequestHandler
+            ->expects($this->exactly(1))
+            ->method('setContentFormat');
+        $ajaxRequestHandler
+            ->expects($this->exactly(1))
+            ->method('setContent');
+
+        $subject = new MetaDataController();
+        $subject
+            ->setObjectManager($this->getObjectManagerMock());
+        $subject
+            ->updateRecursiveAction(array(), $ajaxRequestHandler);
+    }
+
+    protected function getAjaxRequestHandlerMock()
+    {
+        return $this
+            ->getMockBuilder('TYPO3\CMS\Core\Http\AjaxRequestHandler')
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
     /**


### PR DESCRIPTION
* Remove obsolete CSRF protection (it's already provided by the core using Ajax eIDs)
* Update Interfaces for AjaxRequestHandler injection 
* Make use of the AjaxRequestHandler object for rendering
* Also render Errors via AjaxRequestHandler, including core errors
* Render arrays in json with self-provided http status codes (the core only knows status code 500).
* Test of index function call

Fixes #113