### PR TITLE
 [BUGFIX] Fix fluid parse error in GA javascript

### DIFF
--- a/Resources/Private/Templates/PageParts/ServiceGoogleAnalytics.html
+++ b/Resources/Private/Templates/PageParts/ServiceGoogleAnalytics.html
@@ -1,19 +1,27 @@
-<script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    <if condition = "{gaDomainName}" >
-            < f:then>
-    ga('create', '{gaCode}', {
-        'cookieDomain': '{gaDomainName}',
-        'cookieName': '_gua',
-        'cookieExpires': 20000
-    });
-    </then >
-    < f:else>ga('create', '{gaCode}', 'auto');</f:else>
-    </if>
-    ga('send', 'pageview');
-    <if condition = "{gaIsAnonymize}" > ga('set', 'anonymizeIp', true);</if>
-    <if condition = "{gaCustomizationCode}" > < f:format.html; parseFuncTSPath="">{gaCustomizationCode}</f:format.html></if>;
-</script>
+<f:format.raw value="
+    <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');" />
+<f:if condition="{gaDomainName}">
+    <f:then>
+        <f:format.raw value="
+                ga('create', '{gaCode}', {
+                    'cookieDomain': '{gaDomainName}',
+                    'cookieName': '_gua',
+                    'cookieExpires': 20000
+                });" />
+    </f:then>
+    <f:else>
+        <f:format.raw value="ga('create', '{gaCode}', 'auto');" />
+    </f:else>
+</f:if>
+<f:format.raw value="ga('send', 'pageview');" />
+<f:if condition="{gaIsAnonymize}">
+    <f:format.raw value="ga('set', 'anonymizeIp', true);" />
+</f:if>
+<f:if condition="{gaCustomizationCode}">
+    <f:format.raw value="{gaCustomizationCode};" />
+</f:if>
+<f:format.raw value="</script>" />

--- a/Resources/Private/Templates/PageParts/ServicePiwik.html
+++ b/Resources/Private/Templates/PageParts/ServicePiwik.html
@@ -1,15 +1,24 @@
+<f:format.raw value="
 <script>
     var _paq = _paq || [];
     (function(){
-        var u=(("https:" == document.location.protocol) ? "https://{piwikUrl}/" : "http://{piwikUrl}/");
+        var u=(('https:' == document.location.protocol) ? 'https://{piwikUrl}/' : 'http://{piwikUrl}/');
         _paq.push(['setSiteId', {piwikId}]);
         _paq.push(['setTrackerUrl', u+'piwik.php']);
-        <f:if condition="{piwikDomainName}">_paq.push(['setDomains', '{piwikDomainName}']);</f:if>
-        <f:if condition="{piwikCookieDomainName}">_paq.push(['setCookieDomain', '{piwikCookieDomainName}']);</f:if>
-        <f:if condition="{piwikDoNotTrack}">_paq.push(['setDoNotTrack', '{piwikDoNotTrack}']);</f:if>
-        <f:if condition="{piwikCustomizationCode}">
-            <f:format.html parseFuncTSPath="">{piwikCustomizationCode}</f:format.html>
-        </f:if>
+" />
+<f:if condition="{piwikDomainName}">
+    <f:format.raw value="_paq.push(['setDomains', '{piwikDomainName}']);" />
+</f:if>
+<f:if condition="{piwikCookieDomainName}">
+    <f:format.raw value="_paq.push(['setCookieDomain', '{piwikCookieDomainName}']);" />
+</f:if>
+<f:if condition="{piwikDoNotTrack}">
+    <f:format.raw value="_paq.push(['setDoNotTrack', '{piwikDoNotTrack}']);" />
+</f:if>
+<f:if condition="{piwikCustomizationCode}">
+    <f:format.raw value="{piwikCustomizationCode};" />
+</f:if>
+<f:format.raw value="
         _paq.push(['trackPageView']);
         _paq.push(['enableLinkTracking']);
         var d = document,
@@ -21,4 +30,4 @@
         g.src = u+'piwik.js';
         s.parentNode.insertBefore(g,s);
     })();
-</script><noscript><p><img src="//{piwikUrl}/piwik.php?idsite={piwikId}" style="border:0" alt="" /></p></noscript>
+</script>" /><noscript><p><img src="//{piwikUrl}/piwik.php?idsite={piwikId}" style="border:0" alt="" /></p></noscript>


### PR DESCRIPTION
* Removed semicolon from fluid filter tag
* Removed spaces around comparison operators
* Use raw filter for Javascript for analytics services
* Reformat code

Fixes #179