### PR TITLE
[BUGFIX] Render custom opengraph tags

### DIFF
--- a/Classes/Page/Part/MetatagPart.php
+++ b/Classes/Page/Part/MetatagPart.php
@@ -1320,6 +1320,8 @@ class MetatagPart extends AbstractPart
     protected function generateOpenGraphMetaTags()
     {
         $tsSetupSeoOg = $this->tsSetupSeo['opengraph.'];
+        $connector = $this->objectManager->get('Metaseo\\Metaseo\\Connector');
+        $storeMeta = $connector->getStore();
 
         // Get list of tags (filtered array)
         $ogTagNameList = array_keys($tsSetupSeoOg);
@@ -1346,6 +1348,10 @@ class MetatagPart extends AbstractPart
                     $tsSetupSeoOg[$ogTagName],
                     $tsSetupSeoOg[$ogTagName . '.']
                 );
+            } else {
+                if (array_key_exists($ogTagName, $storeMeta['meta:og']) && '' !== $storeMeta['meta:og'][$ogTagName]) {
+                    $ogTagValue = $storeMeta['meta:og'][$ogTagName];
+                }
             }
 
             if ($ogTagValue !== null && strlen($ogTagValue) >= 1) {


### PR DESCRIPTION
In #214 i mentioned you cannot set already existent ogTags, but i also needed additional tags, which are not possible as well.

This patch adds a last-resort if-branch to check if custom og tags are defined on the connector.

This patch was stitched together in a rush, so please tell me if you want some modifications and I'll amend it.