### PR TITLE
Use only HTTP body for Ajax JSON response

### DIFF
--- a/Classes/Controller/AbstractAjaxController.php
+++ b/Classes/Controller/AbstractAjaxController.php
@@ -38,7 +38,7 @@ use TYPO3\CMS\Extbase\Object\ObjectManager;
  */
 abstract class AbstractAjaxController
 {
-    const CONTENT_FORMAT_JSON = 'json';
+    const CONTENT_FORMAT_JSON = 'jsonbody';
 
     /**
      * Json status indicators


### PR DESCRIPTION
This prevents errors if HTTP header size exceeds max header size. If a lot
of data has to be send within an Ajax response this error will occure if
the response is send within X-JSON header.

Since CONTENT_FORMAT_JSON with value 'json' sends the response within
HTTP body and using X-JSON header the response data is send twice.

Changing CONTENT_FORMAT_JSON to 'jsonbody' onyl the HTTP response body
will contain the response data and header size will not exceed limits.

Fixes  #233