### PR TITLE
Use HTTP body for Ajax JSON responses instead of http-headers

### DIFF
--- a/Classes/Controller/AbstractAjaxController.php
+++ b/Classes/Controller/AbstractAjaxController.php
@@ -38,7 +38,7 @@ use TYPO3\CMS\Extbase\Object\ObjectManager;
  */
 abstract class AbstractAjaxController
 {
-    const CONTENT_FORMAT_JSON = 'json';
+    const CONTENT_FORMAT_JSON = 'jsonbody';
 
     /**
      * Json status indicators

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -138,5 +138,6 @@ Thanks to...
 - Florian Duffner
 - Georg Tiefenbrunn
 - Arne-Kolja Bachstein
+- Paul-Christian Volkmer
 - all other contributors and bug reporters
 - famfamfam for these cool silk icons http://www.famfamfam.com/lab/icons/silk/


### PR DESCRIPTION
This prevents errors if HTTP header size exceeds max header size. If a lot
of data has to be send within an Ajax response this error will occur if
the response is send within X-JSON header.

Since CONTENT_FORMAT_JSON with value 'json' sends the response within
HTTP header (using X-JSON header) the response data is sent twice.

Changing CONTENT_FORMAT_JSON to 'jsonbody' only the HTTP response body
will contain the response data and header size will not exceed limits.

Fixes  #233