### PR TITLE
[BUGFIX] PHP7: Fix testsuite type error

### DIFF
--- a/Tests/Unit/Utility/DatabaseUtilityTest.php
+++ b/Tests/Unit/Utility/DatabaseUtilityTest.php
@@ -109,7 +109,7 @@ class DatabaseUtilityTest extends UnitTestCase
     }
 
     /**
-     * @expectedException \PHPUnit_Framework_Error
+     * @expectedException \TypeError
      */
     public function testConditionInException()
     {


### PR DESCRIPTION
This Bugfix mitigates a testsuite error which occurs when using PHP7:
"Metaseo\Metaseo\Utility\DatabaseUtility::conditionIn()
must be of the type array, string given"

This error did not exist in PHP 5.6

Fixes  #249