### PR TITLE
Datenschutzkonformer Tracking-Code

### DIFF
--- a/Resources/Private/Templates/PageParts/ServiceGoogleAnalytics.html
+++ b/Resources/Private/Templates/PageParts/ServiceGoogleAnalytics.html
@@ -17,11 +17,11 @@
         <f:format.raw value="ga('create', '{gaCode}', 'auto');" />
     </f:else>
 </f:if>
-<f:format.raw value="ga('send', 'pageview');" />
-<f:if condition="{gaIsAnonymize}">
-    <f:format.raw value="ga('set', 'anonymizeIp', true);" />
-</f:if>
 <f:if condition="{gaCustomizationCode}">
     <f:format.raw value="{gaCustomizationCode};" />
 </f:if>
+<f:if condition="{gaIsAnonymize}">
+    <f:format.raw value="ga('set', 'anonymizeIp', true);" />
+</f:if>
+<f:format.raw value="ga('send', 'pageview');" />
 <f:format.raw value="</script>" />


### PR DESCRIPTION
It seems to be very important that configuration of analytics (in particular **ga('set', 'anonymizeIp', true)**) is set before **ga('send', 'pageview')** is performed.

https://www.datenschutzbeauftragter-info.de/fachbeitraege/google-analytics-datenschutzkonform-einsetzen/
https://developers.google.com/analytics/devguides/collection/analyticsjs/ip-anonymization
https://support.google.com/analytics/answer/2763052?hl=en
