### PR TITLE
fixed canonical tag generation

### DIFF
--- a/Classes/Page/Part/MetatagPart.php
+++ b/Classes/Page/Part/MetatagPart.php
@@ -1332,7 +1332,7 @@ class MetatagPart extends AbstractPart
     {
         //User has specified a canonical URL in the page properties
         if (!empty($this->pageRecord['tx_metaseo_canonicalurl'])) {
-            return $this->pageRecord['tx_metaseo_canonicalurl'];
+        	return $this->generateLink($this->pageRecord['tx_metaseo_canonicalurl']);
         }
 
         //Fallback to global settings to generate Url

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -139,5 +139,6 @@ Thanks to...
 - Georg Tiefenbrunn
 - Arne-Kolja Bachstein
 - Paul-Christian Volkmer
+- Dominik Steinborn
 - all other contributors and bug reporters
 - famfamfam for these cool silk icons http://www.famfamfam.com/lab/icons/silk/


### PR DESCRIPTION
Added call to ´generateLink´ method to fix problem with user specified canonical url in page properties.

Fixes #224 
