### PR TITLE
[BUGFIX] Marker not replaced when at beginning of string

### DIFF
--- a/Classes/Page/Part/MetatagPart.php
+++ b/Classes/Page/Part/MetatagPart.php
@@ -633,10 +633,10 @@ class MetatagPart extends AbstractPart
         foreach ($keyList as $key) {
             if (!empty($tags[$key]['attributes'])) {
                 foreach ($markerList as $marker => $value) {
-                    // only replace markers if they are present
                     unset($metaTagAttribute);
                     foreach ($tags[$key]['attributes'] as &$metaTagAttribute) {
-                        if (strpos($metaTagAttribute, $marker)) {
+                        // only replace markers if they are present
+                        if (strpos($metaTagAttribute, $marker) !== false) {
                             $metaTagAttribute = str_replace($marker, $value, $metaTagAttribute);
                         }
                     }


### PR DESCRIPTION
* Affects multiple meta tags, including copyright

 Fixes #295