### PR TITLE
[TASK] Markers: Remove obsolete unset()

### DIFF
--- a/Classes/Page/Part/MetatagPart.php
+++ b/Classes/Page/Part/MetatagPart.php
@@ -633,14 +633,12 @@ class MetatagPart extends AbstractPart
         foreach ($keyList as $key) {
             if (!empty($tags[$key]['attributes'])) {
                 foreach ($markerList as $marker => $value) {
-                    unset($metaTagAttribute);
                     foreach ($tags[$key]['attributes'] as &$metaTagAttribute) {
                         // only replace markers if they are present
                         if (strpos($metaTagAttribute, $marker) !== false) {
                             $metaTagAttribute = str_replace($marker, $value, $metaTagAttribute);
                         }
                     }
-                    unset($metaTagAttribute);
                 }
             }
         }


### PR DESCRIPTION
* No use for undefined variable
* Not beneficial in function/loop
* Dangerous because of 'by reference'
* Still replaces markers without the unset

 Issue #295
 Related #167