### PR TITLE
[TASK] Markers: Remove obsolete unset()

### DIFF
--- a/Classes/Backend/Module/AbstractModule.php
+++ b/Classes/Backend/Module/AbstractModule.php
@@ -73,7 +73,6 @@ abstract class AbstractModule extends ActionController
      */
     protected function translateList(array $list)
     {
-        unset($token);
         foreach ($list as &$token) {
             if (!empty($token)) {
                 if (is_array($token)) {
@@ -83,7 +82,6 @@ abstract class AbstractModule extends ActionController
                 }
             }
         }
-        unset($token);
 
         return $list;
     }

--- a/Classes/Controller/Ajax/PageSeo/MetaDataController.php
+++ b/Classes/Controller/Ajax/PageSeo/MetaDataController.php
@@ -50,8 +50,6 @@ class MetaDataController extends AbstractPageSeoController
     protected function getIndex(array $page, $depth, $sysLanguage)
     {
         $list = $this->getPageSeoDao()->index($page, $depth, $sysLanguage, $this->fieldList);
-
-        unset($row);
         foreach ($list as &$row) {
             if (!empty($row['lastupdated'])) {
                 $row['lastupdated'] = date('Y-m-d', $row['lastupdated']);
@@ -59,7 +57,6 @@ class MetaDataController extends AbstractPageSeoController
                 $row['lastupdated'] = '';
             }
         }
-        unset($row);
 
         return $list;
     }

--- a/Classes/Controller/BackendControlCenterController.php
+++ b/Classes/Controller/BackendControlCenterController.php
@@ -114,7 +114,6 @@ class BackendControlCenterController extends AbstractStandardModule
         // Build root page list
         // #################
 
-        unset($page);
         foreach ($rootPageList as $pageId => &$page) {
             // Domain list
             $page['domainList'] = '';
@@ -136,7 +135,6 @@ class BackendControlCenterController extends AbstractStandardModule
             $page['sitemapLink']   = RootPageUtility::getSitemapIndexUrl($pageId);
             $page['robotsTxtLink'] = RootPageUtility::getRobotsTxtUrl($pageId);
         }
-        unset($page);
 
         // check if there is any root page
         if (empty($rootPageList)) {

--- a/Classes/Controller/BackendRootSettingsController.php
+++ b/Classes/Controller/BackendRootSettingsController.php
@@ -112,7 +112,6 @@ class BackendRootSettingsController extends AbstractStandardModule
         // Build root page list
         // #################
 
-        unset($page);
         foreach ($rootPageList as $pageId => &$page) {
             // Domain list
             $page['domainList'] = '';
@@ -131,7 +130,6 @@ class BackendRootSettingsController extends AbstractStandardModule
                 '&edit[tx_metaseo_setting_root][' . $rootSettingList[$pageId]['uid'] . ']=edit'
             );
         }
-        unset($page);
 
         // check if there is any root page
         if (empty($rootPageList)) {

--- a/Classes/Controller/BackendSitemapController.php
+++ b/Classes/Controller/BackendSitemapController.php
@@ -103,8 +103,6 @@ class BackendSitemapController extends AbstractStandardModule
         // Build root page list
         // #################
 
-
-        unset($page);
         foreach ($rootPageList as $pageId => &$page) {
             $stats = array(
                 'sum_pages'     => 0,
@@ -151,7 +149,6 @@ class BackendSitemapController extends AbstractStandardModule
 
             $page['stats'] = $stats;
         }
-        unset($page);
 
         // check if there is any root page
         if (empty($rootPageList)) {

--- a/Classes/Dao/PageSeoDao.php
+++ b/Classes/Dao/PageSeoDao.php
@@ -102,7 +102,6 @@ class PageSeoDao extends Dao
             $defaultOverlayStatus = 2;
         }
 
-        unset($row);
         foreach ($list as &$row) {
             // Set field as main fields
             foreach ($fieldList as $fieldName) {
@@ -112,7 +111,6 @@ class PageSeoDao extends Dao
 
             $row['_depth'] = $this->listCalcDepth($row['uid'], $rootLineRaw);
         }
-        unset($row);
 
         // ############################
         // Language overlay
@@ -142,13 +140,11 @@ class PageSeoDao extends Dao
             );
 
             // update all overlay status field to "from base"
-            unset($row);
             foreach ($list as &$row) {
                 foreach ($overlayFieldList as $fieldName) {
                     $row['_overlay'][$fieldName] = 0;
                 }
             }
-            unset($row);
 
             while ($overlayRow = DatabaseUtility::connection()->sql_fetch_assoc($res)) {
                 $pageOriginalId = $overlayRow['pid'];

--- a/Classes/Utility/SitemapUtility.php
+++ b/Classes/Utility/SitemapUtility.php
@@ -101,7 +101,6 @@ class SitemapUtility
         }
 
         // Escape/Quote data
-        unset($pageDataValue);
         foreach ($pageData as &$pageDataValue) {
             if ($pageDataValue === null) {
                 $pageDataValue = 'NULL';
@@ -113,7 +112,6 @@ class SitemapUtility
                 $pageDataValue = DatabaseUtility::quote($pageDataValue, 'tx_metaseo_sitemap');
             }
         }
-        unset($pageDataValue);
 
         // only process each page once to keep sql-statements at a normal level
         if (empty($cache[$pageHash])) {


### PR DESCRIPTION
* No use for undefined variable
* Not beneficial in function/loop
* Dangerous because of 'by reference'
* Still replaces markers without the unset

 Fixes #167