### PR TITLE
[BUGFIX] Enable preview mode in pagetitle simulator

### DIFF
--- a/Classes/Controller/Ajax/AbstractPageSeoController.php
+++ b/Classes/Controller/Ajax/AbstractPageSeoController.php
@@ -387,7 +387,9 @@ abstract class AbstractPageSeoController extends AbstractAjaxController implemen
      */
     protected function getPageRepository()
     {
-        return $this->objectManager->get('TYPO3\\CMS\\Frontend\\Page\\PageRepository');
+        $pageRepository = $this->objectManager->get('TYPO3\\CMS\\Frontend\\Page\\PageRepository');
+        $pageRepository->versioningPreview = true; //enable preview mode
+        return $pageRepository;
     }
 
     /**


### PR DESCRIPTION
* Now simulates titles also for hidden pages
* Also does not show title of parent page when page is hidden

Fixes #93