### PR TITLE
Select fields without "renderType" are deprecated in table "pages"

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -51,6 +51,7 @@ $tempColumns = array(
         'label'   => 'LLL:EXT:metaseo/Resources/Private/Language/TCA/locallang.xlf:pages.tx_metaseo_inheritance',
         'config'  => array(
             'type'     => 'select',
+            'renderType' => 'selectSingle',
             'items'    => array(
                 array(
                     'LLL:EXT:metaseo/Resources/Private/Language/TCA/locallang.xlf:pages.tx_metaseo_inheritance.I.0',
@@ -118,6 +119,7 @@ $tempColumns = array(
         'label'   => 'LLL:EXT:metaseo/Resources/Private/Language/TCA/locallang.xlf:pages.tx_metaseo_change_frequency',
         'config'  => array(
             'type'     => 'select',
+            'renderType' => 'selectSingle',
             'items'    => array(
                 array(
                     'LLL:EXT:metaseo/Resources/Private/Language/TCA/locallang.xlf:'

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ It's a replacement for the "metatag" extension and the successor of the disconti
   + Composer: dev-develop
 
 For version specific information see [changelog for MetaSEO](CHANGELOG.md)
-
+ 
 
 ## Composer Support
 


### PR DESCRIPTION
* Using select fields without the "renderType" setting is deprecated
  in table "pages" and column "tx_metaseo_inheritance"
* Using select fields without the "renderType" setting is deprecated
  in table "pages" and column "tx_metaseo_change_frequency"

Fixes #326