### PR TITLE
Language overlay bugfix

### DIFF
--- a/Classes/Dao/PageSeoDao.php
+++ b/Classes/Dao/PageSeoDao.php
@@ -138,7 +138,8 @@ class PageSeoDao extends Dao
             $res = DatabaseUtility::connection()->exec_SELECTquery(
                 implode(',', $queryFieldList),
                 'pages_language_overlay',
-                'pid IN(' . implode(',', $pageIdList) . ') AND sys_language_uid = ' . (int)$sysLanguage
+                'pid IN(' . implode(',', $pageIdList) . ') AND sys_language_uid = ' . (int)$sysLanguage.'
+                 AND deleted = 0'
             );
 
             // update all overlay status field to "from base"


### PR DESCRIPTION
Wenn eine gelöschte language overlay row in db vorhanden ist wird immer diese verarbeitet.
Im Frontend erscheint deshalb nicht das richtige Browsertitle weil das richtige (nicht gelöschte) language overlay row in db wird nie verarbeitet.