### PR TITLE
Fixes #343

### DIFF
--- a/Classes/Utility/GeneralUtility.php
+++ b/Classes/Utility/GeneralUtility.php
@@ -392,7 +392,7 @@ class GeneralUtility
             /** @var \TYPO3\CMS\Extbase\SignalSlot\Dispatcher $signalSlotDispatcher */
             $signalSlotDispatcher = $objectManager->get('TYPO3\\CMS\\Extbase\\SignalSlot\\Dispatcher');
         }
-        list($args) = $signalSlotDispatcher->dispatch($class, $name, array($args, $obj));
+        list($args) = $signalSlotDispatcher->dispatch($class, $name, array(&$args, $obj));
     }
 
 

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -142,5 +142,6 @@ Thanks to...
 - Paul-Christian Volkmer
 - Dominik Steinborn
 - Attila Glück
+- Marcel Schuhbauer
 - all other contributors and bug reporters
 - famfamfam for these cool silk icons http://www.famfamfam.com/lab/icons/silk/


### PR DESCRIPTION
Adds missing call by reference in $signalSlotDispatcher->dispatch inside GeneralUtility->callHookAndSignal() 