### PR TITLE
[FEATURE] Add image to OpenGraph tags

### DIFF
--- a/Classes/Page/Part/MetatagPart.php
+++ b/Classes/Page/Part/MetatagPart.php
@@ -1420,8 +1420,19 @@ class MetatagPart extends AbstractPart
      */
     protected function generateOpenGraphMetaTags()
     {
+        $prefixes = array('og');
         $tsSetupSeoOg = $this->tsSetupSeo['opengraph.'];
+        $this->convertOpenGraphTypoScriptToMetaTags($prefixes, $tsSetupSeoOg);
+    }
 
+    /**
+     * Convert nested TypoScript to OpenGraph MetaTags
+     *
+     * @param array $prefixes
+     * @param array $tsSetupSeoOg
+     */
+    protected function convertOpenGraphTypoScriptToMetaTags(array $prefixes, array $tsSetupSeoOg)
+    {
         // Get list of tags (filtered array)
         $ogTagNameList = array_keys($tsSetupSeoOg);
         $ogTagNameList = array_unique(
@@ -1447,13 +1458,20 @@ class MetatagPart extends AbstractPart
                     $tsSetupSeoOg[$ogTagName],
                     $tsSetupSeoOg[$ogTagName . '.']
                 );
+            } elseif (!array_key_exists($ogTagName, $tsSetupSeoOg) && array_key_exists($ogTagName . '.', $tsSetupSeoOg)) {
+                // Nested object (e.g. image)
+                array_push($prefixes, $ogTagName);
+                $this->convertOpenGraphTypoScriptToMetaTags($prefixes, $tsSetupSeoOg[$ogTagName . '.']);
+                array_pop($prefixes);
             }
 
             if ($ogTagValue !== null && strlen($ogTagValue) >= 1) {
-                $this->metaTagList['og.' . $ogTagName] = array(
+                $path = $prefixes;
+                $path[] = $ogTagName;
+                $this->metaTagList[implode('.', $path)] = array(
                     'tag'        => 'meta',
                     'attributes' => array(
-                        'property' => 'og:' . $ogTagName,
+                        'property' => implode(':', $path),
                         'content'  => $ogTagValue,
                     ),
                 );

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -66,6 +66,14 @@ $tempColumns = array(
             'maxitems' => 1
         )
     ),
+    'tx_metaseo_opengraph_image' => array(
+        'exclude' => 1,
+        'label'   => 'LLL:EXT:metaseo/Resources/Private/Language/TCA/locallang.xlf:pages.tx_metaseo_opengraph_image',
+        'config'  => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig('tx_metaseo_opengraph_image', array(
+                'maxitems' => 1
+            )
+        )
+    ),
     'tx_metaseo_is_exclude'       => array(
         'label'   => 'LLL:EXT:metaseo/Resources/Private/Language/TCA/locallang.xlf:pages.tx_metaseo_is_exclude',
         'exclude' => 1,
@@ -223,6 +231,11 @@ $GLOBALS['TCA']['pages']['palettes']['tx_metaseo_pagetitle'] = array(
     'canNotCollapse' => 1
 );
 
+$GLOBALS['TCA']['pages']['palettes']['tx_metaseo_opengraph'] = array(
+    'showitem'       => 'tx_metaseo_opengraph_image',
+    'canNotCollapse' => 1
+);
+
 $GLOBALS['TCA']['pages']['palettes']['tx_metaseo_crawler'] = array(
     'showitem'       => 'tx_metaseo_is_exclude,--linebreak--,tx_metaseo_canonicalurl',
     'canNotCollapse' => 1
@@ -252,6 +265,7 @@ $GLOBALS['TCA']['pages']['palettes']['tx_metaseo_geo'] = array(
     'pages',
     '--div--;LLL:EXT:metaseo/Resources/Private/Language/TCA/locallang.xlf:pages.tab.seo;,--palette--;'
     . 'LLL:EXT:metaseo/Resources/Private/Language/TCA/locallang.xlf:pages.palette.pagetitle;tx_metaseo_pagetitle,'
+    . '--palette--;LLL:EXT:metaseo/Resources/Private/Language/TCA/locallang.xlf:pages.palette.opengraph;tx_metaseo_opengraph,'
     . '--palette--;LLL:EXT:metaseo/Resources/Private/Language/TCA/locallang.xlf:pages.palette.geo;tx_metaseo_geo,'
     . '--palette--;LLL:EXT:metaseo/Resources/Private/Language/TCA/locallang.xlf:pages.palette.crawler;'
     . 'tx_metaseo_crawler,--palette--;LLL:EXT:metaseo/Resources/Private/Language/TCA/locallang.xlf:'

--- a/Configuration/TCA/Overrides/pages_language_overlay.php
+++ b/Configuration/TCA/Overrides/pages_language_overlay.php
@@ -26,6 +26,15 @@ $tempColumns = array(
             'eval'     => 'trim',
         )
     ),
+    'tx_metaseo_opengraph_image' => array(
+        'exclude' => 1,
+        'label'   => 'LLL:EXT:metaseo/Resources/Private/Language/TCA/locallang.xlf:'
+            . 'pages.tx_metaseo_opengraph_image',
+        'config'  => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig('tx_metaseo_opengraph_image', array(
+                'maxitems' => 1
+            )
+        )
+    ),
     'tx_metaseo_pagetitle_prefix' => array(
         'label'   => 'LLL:EXT:metaseo/Resources/Private/Language/TCA/locallang.xlf:'
             . 'pages.tx_metaseo_pagetitle_prefix',
@@ -91,6 +100,11 @@ $GLOBALS['TCA']['pages_language_overlay']['palettes']['tx_metaseo_pagetitle'] = 
     'canNotCollapse' => 1
 );
 
+$GLOBALS['TCA']['pages_language_overlay']['palettes']['tx_metaseo_opengraph'] = array(
+    'showitem'       => 'tx_metaseo_opengraph_image',
+    'canNotCollapse' => 1
+);
+
 $GLOBALS['TCA']['pages_language_overlay']['palettes']['tx_metaseo_crawler'] = array(
     'showitem'       => 'tx_metaseo_canonicalurl',
     'canNotCollapse' => 1
@@ -108,6 +122,7 @@ $GLOBALS['TCA']['pages_language_overlay']['palettes']['tx_metaseo_crawler'] = ar
     'pages_language_overlay',
     '--div--;LLL:EXT:metaseo/Resources/Private/Language/TCA/locallang.xlf:pages.tab.seo;,--palette--;'
     . 'LLL:EXT:metaseo/Resources/Private/Language/TCA/locallang.xlf:pages.palette.pagetitle;tx_metaseo_pagetitle,'
+    . '--palette--;LLL:EXT:metaseo/Resources/Private/Language/TCA/locallang.xlf:pages.palette.opengraph;tx_metaseo_opengraph,'
     . '--palette--;LLL:EXT:metaseo/Resources/Private/Language/TCA/locallang.xlf:pages.palette.crawler;'
     . 'tx_metaseo_crawler',
     '',

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -62,6 +62,12 @@ plugin.metaseo {
     # cat=plugin.metaseo.metaTags/enable/26; type=boolean; label= OpenGraph Tags: Enable generation of OpenGraph Tags
     metaTags.opengraph = 1
 
+    # cat=plugin.metaseo.metaTags/page/20; type=string; label= Open Graph image width
+    metaTags.opengraphImageWidth = 1200c
+
+    # cat=plugin.metaseo.metaTags/page/21; type=string; label= Open Graph image height
+    metaTags.opengraphImageHeight = 630c
+
     # cat=plugin.metaseo.metaTags/enable/27; type=boolean; label= Publish Page Expire Time: Anounce Expire Tag (TYPO3's enddate in content elements).
     metaTags.useExpire = 1
 

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -145,6 +145,52 @@ plugin.metaseo {
                 field = title
             }
 
+            image {
+                url = FILES
+                url {
+                    references {
+                        table = pages
+                        uid.data = page:uid
+                        fieldName = tx_metaseo_opengraph_image
+                    }
+                    renderObj = TEXT
+                    renderObj {
+                        typolink {
+                            parameter {
+                                stdWrap.cObject = IMG_RESOURCE
+                                stdWrap.cObject {
+                                    file {
+                                        import.data = file:current:uid
+                                        treatIdAsReference = 1
+                                        width = {$plugin.metaseo.metaTags.opengraphImageWidth}
+                                        height = {$plugin.metaseo.metaTags.opengraphImageHeight}
+                                    }
+                                }
+                            }
+                            returnLast = url
+                            forceAbsoluteUrl = 1
+                        }
+                    }
+                }
+
+                width = TEXT
+                width {
+                    data = TSFE:lastImgResourceInfo|0
+                }
+
+                height = TEXT
+                height {
+                    data = TSFE:lastImgResourceInfo|1
+                }
+
+                type = TEXT
+                type {
+                    wrap = image/|
+                    data = TSFE:lastImgResourceInfo|2
+                    required = 1
+                }
+            }
+
             type = article
             admins = 
             email = {$plugin.metaseo.metaTags.email}

--- a/Resources/Private/Language/TCA/de.locallang.xlf
+++ b/Resources/Private/Language/TCA/de.locallang.xlf
@@ -12,6 +12,10 @@
                 <source>Pagetitle</source>
                 <target>Seitentitel</target>
             </trans-unit>
+            <trans-unit id="pages.palette.opengraph" xml:space="preserve" approved="yes">
+                <source>Open Graph</source>
+                <target>Open Graph</target>
+            </trans-unit>
             <trans-unit id="pages.palette.geo" xml:space="preserve" approved="yes">
                 <source>Geo position</source>
                 <target>Geo Position</target>
@@ -47,6 +51,10 @@
             <trans-unit id="pages_language_overlay.tx_metaseo_pagetitle_rel" xml:space="preserve" approved="yes">
                 <source>Browsertitle</source>
                 <target>Browsertitel</target>
+            </trans-unit>
+            <trans-unit id="pages.tx_metaseo_opengraph_image" xml:space="preserve" approved="yes">
+                <source>Image (1200 x 630 px recommended)</source>
+                <target>Bild (1200 x 630 px empfohlen)</target>
             </trans-unit>
             <trans-unit id="pages.tx_metaseo_is_exclude" xml:space="preserve" approved="yes">
                 <source>Exclude page from SearchEngines</source>

--- a/Resources/Private/Language/TCA/locallang.xlf
+++ b/Resources/Private/Language/TCA/locallang.xlf
@@ -10,6 +10,9 @@
             <trans-unit id="pages.palette.pagetitle" xml:space="preserve">
                 <source>Pagetitle</source>
             </trans-unit>
+            <trans-unit id="pages.palette.opengraph" xml:space="preserve">
+                <source>Open Graph</source>
+            </trans-unit>
             <trans-unit id="pages.palette.geo" xml:space="preserve">
                 <source>Geo position</source>
             </trans-unit>
@@ -36,6 +39,9 @@
             </trans-unit>
             <trans-unit id="pages_language_overlay.tx_metaseo_pagetitle_rel" xml:space="preserve">
                 <source>Browsertitle</source>
+            </trans-unit>
+            <trans-unit id="pages.tx_metaseo_opengraph_image" xml:space="preserve">
+                <source>Image (1200 x 630 px recommended)</source>
             </trans-unit>
             <trans-unit id="pages.tx_metaseo_is_exclude" xml:space="preserve">
                 <source>Exclude page from SearchEngines</source>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -6,6 +6,7 @@ CREATE TABLE pages (
     tx_metaseo_pagetitle_rel varchar(255) DEFAULT '' NOT NULL,
     tx_metaseo_pagetitle_prefix varchar(255) DEFAULT '' NOT NULL,
     tx_metaseo_pagetitle_suffix varchar(255) DEFAULT '' NOT NULL,
+    tx_metaseo_opengraph_image int(11) unsigned DEFAULT '0' NOT NULL,
     tx_metaseo_is_exclude int(1) DEFAULT '0' NOT NULL,
     tx_metaseo_inheritance int(11) DEFAULT '0' NOT NULL,
     tx_metaseo_canonicalurl varchar(255) DEFAULT '' NOT NULL,
@@ -25,6 +26,7 @@ CREATE TABLE pages_language_overlay (
     tx_metaseo_pagetitle_rel varchar(255) DEFAULT '' NOT NULL,
     tx_metaseo_pagetitle_prefix varchar(255) DEFAULT '' NOT NULL,
     tx_metaseo_pagetitle_suffix varchar(255) DEFAULT '' NOT NULL,
+    tx_metaseo_opengraph_image int(11) unsigned DEFAULT '0' NOT NULL,
     tx_metaseo_canonicalurl varchar(255) DEFAULT '' NOT NULL
 );
 


### PR DESCRIPTION
Add dedicated image field for OpenGraph to pages and pages_language_overlay tables. Add support for rendering nested TypoScript/OpenGraph configuration (e.g. og:image:width).

Closes #172