### PR TITLE
[TASK] Make priority and lastmod tag optional

### DIFF
--- a/Classes/Sitemap/Generator/XmlGenerator.php
+++ b/Classes/Sitemap/Generator/XmlGenerator.php
@@ -237,13 +237,18 @@ class XmlGenerator extends AbstractGenerator
             // #####################################
             $ret .= '<url>';
             $ret .= '<loc>' . htmlspecialchars($pageUrl) . '</loc>';
-            $ret .= '<lastmod>' . $pageModificationDate . '</lastmod>';
+
+            if ($this->tsSetup['enableLastMod']) {
+                $ret .= '<lastmod>' . $pageModificationDate . '</lastmod>';
+            }
 
             if (!empty($pageChangeFrequency)) {
                 $ret .= '<changefreq>' . htmlspecialchars($pageChangeFrequency) . '</changefreq>';
             }
 
-            $ret .= '<priority>' . $pagePriority . '</priority>';
+            if ($this->tsSetup['enablePriority']) {
+                $ret .= '<priority>' . $pagePriority . '</priority>';
+            }
 
             $ret .= '</url>';
         }

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -175,4 +175,10 @@ plugin.metaseo {
 
     # cat=plugin.metaseo.sitemap/index/01; type=boolean; label= Index no_cache pages: Allow to index no_cache pages
     sitemap.index.allowNoCache = 0
+
+    # cat=plugin.metaseo.sitemap/index/01; type=boolean; label= Priority tag in sitemap: Include priority tag in sitemap
+    sitemap.enablePriority = 1
+
+    # cat=plugin.metaseo.sitemap/index/01; type=boolean; label= Lastmod tag in sitemap: Include lastmod tag in sitemap
+    sitemap.enableLastMod = 1
 }

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -413,6 +413,8 @@ plugin.metaseo {
         pagePriority = {$plugin.metaseo.sitemap.pagePriority}
         changeFrequency = {$plugin.metaseo.sitemap.changeFrequency}
         expiration = {$plugin.metaseo.sitemap.expiration}
+        enablePriority = {$plugin.metaseo.sitemap.enablePriority}
+        enableLastMod = {$plugin.metaseo.sitemap.enableLastMod}
 
         # indexer settings
         index {

--- a/Documentation/Constants/Index.rst
+++ b/Documentation/Constants/Index.rst
@@ -285,6 +285,10 @@ Page priority                       Default page priority if the page has no own
                                     ( `[page priority] – [priority modificator] ) *`
                                     ( `1/[page depth] * [page multiplier] )`
 
+Priority tag in sitemap             Include priority tag in sitemap                              1
+
+Lastmod tag in sitemap              Include lastmod tag in sitemap                               1
+
 Page priority depth multiplier      Page depth multiplier, see formula in page priority          1
 
 Page priority depth modificator     Page depth modificator, see formula in page priority         1

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -142,5 +142,6 @@ Thanks to...
 - Paul-Christian Volkmer
 - Dominik Steinborn
 - Attila Glück
+- Marcus Müller
 - all other contributors and bug reporters
 - famfamfam for these cool silk icons http://www.famfamfam.com/lab/icons/silk/


### PR DESCRIPTION
This PR  adds two typoscript-constants to disable the `priority` and/or the `lastmod` tag. Documentation was updated, too