### PR TITLE
Fix error with storing sitemap URLs

### DIFF
--- a/Classes/Hook/SitemapIndexHook.php
+++ b/Classes/Hook/SitemapIndexHook.php
@@ -169,7 +169,7 @@ abstract class SitemapIndexHook implements SingletonInterface
     protected static function processLinkUrl($linkUrl)
     {
         static $absRefPrefix = null;
-        static $absRefPrefixLength = 0;
+        $absRefPrefixLength = 0;
         $ret = $linkUrl;
         $tsfe = self::getTsfe();
 


### PR DESCRIPTION
When $absRefPrefixLength is stored between function calls, generations of links to the root page "/" cause it to decrease. When $absRefPrefixLength gets smaller than 0, subsequent URLs are changed when saving them to the sitemap table, or are not saved at all.

See issue #357.