### PR TITLE
[Bugfix] Fix that URLs get shortened in the sitemap

### DIFF
--- a/Classes/Hook/SitemapIndexHook.php
+++ b/Classes/Hook/SitemapIndexHook.php
@@ -184,6 +184,8 @@ abstract class SitemapIndexHook implements SingletonInterface
             }
         }
 
+        $absRefPrefixLengthTmp = $absRefPrefixLength; //makes sure we do not write back to static variable
+
         // remove abs ref prefix
         if ($absRefPrefix !== false && strpos($ret, $absRefPrefix) === 0) {
             $parsedUrl = parse_url($linkUrl);
@@ -193,10 +195,10 @@ abstract class SitemapIndexHook implements SingletonInterface
             ) {
                 //for root pages: treat '/' like a suffix, not like a prefix => don't remove last '/' in that case!
                 //This ensures that for an absRefPrefix = '/abc/' or '/' we return '/' instead of empty strings
-                $absRefPrefixLength--;
+                $absRefPrefixLengthTmp--;
             }
 
-            $ret = substr($ret, $absRefPrefixLength);
+            $ret = substr($ret, $absRefPrefixLengthTmp);
         }
 
         return $ret;


### PR DESCRIPTION
When $absRefPrefixLength is stored between function calls, generation
of links to the root page "/" cause it to decrease, thereby surviving
function calls. When $absRefPrefixLength gets smaller than 0,
subsequent URLs are changed when saving them to the sitemap table,
or they are not saved at all.

Fixes #357