### PR TITLE
[FEATURE] 8LTS/PSR-7: Register Ajax controllers via routes

### DIFF
--- a/Classes/Controller/Ajax/AbstractPageSeoController.php
+++ b/Classes/Controller/Ajax/AbstractPageSeoController.php
@@ -31,7 +31,8 @@ use Metaseo\Metaseo\Controller\AbstractAjaxController;
 use Metaseo\Metaseo\Controller\Ajax\PageSeo as PageSeo;
 use Metaseo\Metaseo\DependencyInjection\Utility\HttpUtility;
 use Metaseo\Metaseo\Exception\Ajax\AjaxException;
-use TYPO3\CMS\Core\Http\AjaxRequestHandler;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * TYPO3 Backend ajax module page
@@ -39,7 +40,7 @@ use TYPO3\CMS\Core\Http\AjaxRequestHandler;
 abstract class AbstractPageSeoController extends AbstractAjaxController implements PageSeoInterface
 {
     const LIST_TYPE = 'undefined';
-    const AJAX_PREFIX = 'tx_metaseo_controller_ajax_pageseo_';
+    const AJAX_PREFIX = 'tx_metaseo_controller_pageseo_';
 
     // ########################################################################
     // Attributes
@@ -73,17 +74,16 @@ abstract class AbstractPageSeoController extends AbstractAjaxController implemen
     /**
      * @inheritDoc
      */
-    public function indexAction($params = array(), AjaxRequestHandler &$ajaxObj = null)
+    public function indexAction(ServerRequestInterface $request, ResponseInterface $response)
     {
         try {
             $this->init();
-            $ajaxObj->setContent($this->executeIndex());
+            $response->getBody()->write(\GuzzleHttp\json_encode($this->executeIndex()));
         } catch (Exception $exception) {
-            $this->ajaxExceptionHandler($exception, $ajaxObj);
+            return $this->ajaxExceptionHandler($exception, $response);
         }
 
-        $ajaxObj->setContentFormat(self::CONTENT_FORMAT_JSON);
-        $ajaxObj->render();
+        return $response;
     }
 
     /**
@@ -139,17 +139,16 @@ abstract class AbstractPageSeoController extends AbstractAjaxController implemen
     /**
      * @inheritDoc
      */
-    public function updateAction($params = array(), AjaxRequestHandler &$ajaxObj = null)
+    public function updateAction(ServerRequestInterface $request, ResponseInterface $response)
     {
         try {
             $this->init();
-            $ajaxObj->setContent($this->executeUpdate());
+            $response->getBody()->write(\GuzzleHttp\json_encode($this->executeUpdate()));
         } catch (Exception $exception) {
-            $this->ajaxExceptionHandler($exception, $ajaxObj);
+            return $this->ajaxExceptionHandler($exception, $response);
         }
 
-        $ajaxObj->setContentFormat(self::CONTENT_FORMAT_JSON);
-        $ajaxObj->render();
+        return $response;
     }
 
     /**
@@ -287,17 +286,16 @@ abstract class AbstractPageSeoController extends AbstractAjaxController implemen
     /**
      * @inheritDoc
      */
-    public function updateRecursiveAction($params = array(), AjaxRequestHandler &$ajaxObj = null)
+    public function updateRecursiveAction(ServerRequestInterface $request, ResponseInterface $response)
     {
         try {
             $this->init();
-            $ajaxObj->setContent($this->executeUpdateRecursive());
+            $request->getBody()->write(\GuzzleHttp\json_encode($this->executeUpdateRecursive()));
         } catch (Exception $exception) {
-            $this->ajaxExceptionHandler($exception, $ajaxObj);
+            return $this->ajaxExceptionHandler($exception, $response);
         }
 
-        $ajaxObj->setContentFormat(self::CONTENT_FORMAT_JSON);
-        $ajaxObj->render();
+        return $response;
     }
 
     /**

--- a/Classes/Controller/Ajax/AbstractPageSeoSimController.php
+++ b/Classes/Controller/Ajax/AbstractPageSeoSimController.php
@@ -26,24 +26,24 @@
 
 namespace Metaseo\Metaseo\Controller\Ajax;
 
-use TYPO3\CMS\Core\Http\AjaxRequestHandler;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 abstract class AbstractPageSeoSimController extends AbstractPageSeoController implements PageSeoSimulateInterface
 {
     /**
      * @inheritDoc
      */
-    public function simulateAction($params = array(), AjaxRequestHandler &$ajaxObj = null)
+    public function simulateAction(ServerRequestInterface $request, ResponseInterface $response)
     {
         try {
             $this->init();
-            $ajaxObj->setContent($this->executeSimulate($this->getLanguage()));
+            $response->getBody()->write(\GuzzleHttp\json_encode($this->executeSimulate($this->getLanguage())));
         } catch (\Exception $exception) {
-            $this->ajaxExceptionHandler($exception, $ajaxObj);
+            return $this->ajaxExceptionHandler($exception, $response);
         }
 
-        $ajaxObj->setContentFormat(self::CONTENT_FORMAT_JSON);
-        $ajaxObj->render();
+        return $response;
     }
 
     /**

--- a/Classes/Controller/Ajax/PageSeoInterface.php
+++ b/Classes/Controller/Ajax/PageSeoInterface.php
@@ -26,44 +26,39 @@
 
 namespace Metaseo\Metaseo\Controller\Ajax;
 
-use TYPO3\CMS\Core\Http\AjaxRequestHandler;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 interface PageSeoInterface
 {
     /**
      * Executes an AJAX request which displays the data (usually as a list)
      *
-     * @param array $params Array of parameters from the AJAX interface, currently unused (as of 6.2.14)
-     *                      becomes available starting with 7.4.0 (c048cede,
-     *                      https://forge.typo3.org/issues/68186)
-     * @param AjaxRequestHandler $ajaxObj Object of type AjaxRequestHandler
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
      *
-     * @return void
+     * @return ResponseInterface
      */
-    public function indexAction($params = array(), AjaxRequestHandler &$ajaxObj = null);
+    public function indexAction(ServerRequestInterface $request, ResponseInterface $response);
 
     /**
      * Executes an AJAX request which updates the data in the database
      *
-     * @param array $params Array of parameters from the AJAX interface, currently unused (as of 6.2.14)
-     *                      becomes available starting with 7.4.0 (c048cede,
-     *                      https://forge.typo3.org/issues/68186)
-     * @param AjaxRequestHandler $ajaxObj Object of type AjaxRequestHandler
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
      *
-     * @return void
+     * @return ResponseInterface
      */
-    public function updateAction($params = array(), AjaxRequestHandler &$ajaxObj = null);
+    public function updateAction(ServerRequestInterface $request, ResponseInterface $response);
 
 
     /**
      * Executes an AJAX request which updates the data in the database recursively
      *
-     * @param array $params Array of parameters from the AJAX interface, currently unused (as of 6.2.14)
-     *                      becomes available starting with 7.4.0 (c048cede,
-     *                      https://forge.typo3.org/issues/68186)
-     * @param AjaxRequestHandler $ajaxObj Object of type AjaxRequestHandler
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
      *
-     * @return void
+     * @return ResponseInterface
      */
-    public function updateRecursiveAction($params = array(), AjaxRequestHandler &$ajaxObj = null);
+    public function updateRecursiveAction(ServerRequestInterface $request, ResponseInterface $response);
 }

--- a/Classes/Controller/Ajax/PageSeoSimulateInterface.php
+++ b/Classes/Controller/Ajax/PageSeoSimulateInterface.php
@@ -26,19 +26,18 @@
 
 namespace Metaseo\Metaseo\Controller\Ajax;
 
-use TYPO3\CMS\Core\Http\AjaxRequestHandler;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 interface PageSeoSimulateInterface extends PageSeoInterface
 {
     /**
      * Executes an AJAX request which simulates field values
      *
-     * @param array $params Array of parameters from the AJAX interface, currently unused (as of 6.2.14)
-     *                      becomes available starting with 7.4.0 (c048cede,
-     *                      https://forge.typo3.org/issues/68186)
-     * @param AjaxRequestHandler $ajaxObj Object of type AjaxRequestHandler
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
      *
-     * @return void
+     * @return ResponseInterface
      */
-    public function simulateAction($params = array(), AjaxRequestHandler &$ajaxObj = null);
+    public function simulateAction(ServerRequestInterface $request, ResponseInterface $response);
 }

--- a/Classes/Controller/Ajax/SitemapController.php
+++ b/Classes/Controller/Ajax/SitemapController.php
@@ -32,29 +32,29 @@ use Metaseo\Metaseo\DependencyInjection\Utility\HttpUtility;
 use Metaseo\Metaseo\Exception\Ajax\AjaxException;
 use Metaseo\Metaseo\Utility\DatabaseUtility;
 use Metaseo\Metaseo\Utility\SitemapUtility;
-use TYPO3\CMS\Core\Http\AjaxRequestHandler;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * TYPO3 Backend ajax module sitemap
  */
 class SitemapController extends AbstractAjaxController implements SitemapInterface
 {
-    const AJAX_PREFIX = 'tx_metaseo_controller_ajax_sitemap';
+    const AJAX_PREFIX = 'tx_metaseo_controller_sitemap';
 
     /**
      * @inheritDoc
      */
-    public function indexAction($params = array(), AjaxRequestHandler &$ajaxObj = null)
+    public function indexAction(ServerRequestInterface $request, ResponseInterface $response)
     {
         try {
             $this->init();
-            $ajaxObj->setContent($this->executeIndex());
+            $response->getBody()->write(\GuzzleHttp\json_encode($this->executeIndex()));
         } catch (Exception $exception) {
-            $this->ajaxExceptionHandler($exception, $ajaxObj);
+            return $this->ajaxExceptionHandler($exception, $response);
         }
 
-        $ajaxObj->setContentFormat(self::CONTENT_FORMAT_JSON);
-        $ajaxObj->render();
+        return $response;
     }
 
     /**
@@ -168,17 +168,16 @@ class SitemapController extends AbstractAjaxController implements SitemapInterfa
     /**
      * @inheritDoc
      */
-    public function blacklistAction($params = array(), AjaxRequestHandler &$ajaxObj = null)
+    public function blacklistAction(ServerRequestInterface $request, ResponseInterface $response)
     {
         try {
             $this->init();
-            $ajaxObj->setContent($this->executeBlacklist());
+            $response->getBody()->write(\GuzzleHttp\json_encode($this->executeBlacklist()));
         } catch (Exception $exception) {
-            $this->ajaxExceptionHandler($exception, $ajaxObj);
+            return $this->ajaxExceptionHandler($exception, $response);
         }
 
-        $ajaxObj->setContentFormat(self::CONTENT_FORMAT_JSON);
-        $ajaxObj->render();
+        return $response;
     }
 
     /*
@@ -220,17 +219,16 @@ class SitemapController extends AbstractAjaxController implements SitemapInterfa
     /**
      * @inheritDoc
      */
-    public function whitelistAction($params = array(), AjaxRequestHandler &$ajaxObj = null)
+    public function whitelistAction(ServerRequestInterface $request, ResponseInterface $response)
     {
         try {
             $this->init();
-            $ajaxObj->setContent($this->executeWhitelist());
+            $response->getBody()->write(\GuzzleHttp\json_encode($this->executeWhitelist()));
         } catch (Exception $exception) {
-            $this->ajaxExceptionHandler($exception, $ajaxObj);
+            return $this->ajaxExceptionHandler($exception, $response);
         }
 
-        $ajaxObj->setContentFormat(self::CONTENT_FORMAT_JSON);
-        $ajaxObj->render();
+        return $response;
     }
 
     /*
@@ -272,17 +270,16 @@ class SitemapController extends AbstractAjaxController implements SitemapInterfa
     /**
      * @inheritDoc
      */
-    public function deleteAction($params = array(), AjaxRequestHandler &$ajaxObj = null)
+    public function deleteAction(ServerRequestInterface $request, ResponseInterface $response)
     {
         try {
             $this->init();
-            $ajaxObj->setContent($this->executeDelete());
+            $response->getBody()->write(\GuzzleHttp\json_encode($this->executeDelete()));
         } catch (Exception $exception) {
-            $this->ajaxExceptionHandler($exception, $ajaxObj);
+            return $this->ajaxExceptionHandler($exception, $response);
         }
 
-        $ajaxObj->setContentFormat(self::CONTENT_FORMAT_JSON);
-        $ajaxObj->render();
+        return $response;
     }
 
     /**
@@ -323,17 +320,16 @@ class SitemapController extends AbstractAjaxController implements SitemapInterfa
     /**
      * @inheritDoc
      */
-    public function deleteAllAction($params = array(), AjaxRequestHandler &$ajaxObj = null)
+    public function deleteAllAction(ServerRequestInterface $request, ResponseInterface $response)
     {
         try {
             $this->init();
-            $ajaxObj->setContent($this->executeDeleteAll());
+            $response->getBody()->write(\GuzzleHttp\json_encode($this->executeDeleteAll()));
         } catch (Exception $exception) {
-            $this->ajaxExceptionHandler($exception, $ajaxObj);
+            return $this->ajaxExceptionHandler($exception, $response);
         }
 
-        $ajaxObj->setContentFormat(self::CONTENT_FORMAT_JSON);
-        $ajaxObj->render();
+        return $response;
     }
 
     /**

--- a/Classes/Controller/Ajax/SitemapInterface.php
+++ b/Classes/Controller/Ajax/SitemapInterface.php
@@ -26,70 +26,58 @@
 
 namespace Metaseo\Metaseo\Controller\Ajax;
 
-use TYPO3\CMS\Core\Http\AjaxRequestHandler;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 interface SitemapInterface
 {
     /**
      * Executes an AJAX request which displays the data (usually as a list)
      *
-     * @param array $params Array of parameters from the AJAX interface, currently unused (as of 6.2.14)
-     *                      becomes available starting with 7.4.0 (c048cede,
-     *                      https://forge.typo3.org/issues/68186)
-     * @param AjaxRequestHandler $ajaxObj Object of type AjaxRequestHandler
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
      *
-     * @return void
+     * @return ResponseInterface
      */
-    public function indexAction($params = array(), AjaxRequestHandler &$ajaxObj = null);
+    public function indexAction(ServerRequestInterface $request, ResponseInterface $response);
 
     /**
      * Blacklists a sitemap entry so that it does not appear in the sitemap presented to search engines
      *
-     * @param array $params Array of parameters from the AJAX interface, currently unused (as of 6.2.14)
-     *                      becomes available starting with 7.4.0 (c048cede,
-     *                      https://forge.typo3.org/issues/68186)
-     * @param AjaxRequestHandler $ajaxObj Object of type AjaxRequestHandler
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
      *
-     * @return void
+     * @return ResponseInterface
      */
-    public function blacklistAction($params = array(), AjaxRequestHandler &$ajaxObj = null);
+    public function blacklistAction(ServerRequestInterface $request, ResponseInterface $response);
 
     /**
      * Undoes the blacklist operation
      *
-     * @param array $params Array of parameters from the AJAX interface, currently unused (as of 6.2.14)
-     *                      becomes available starting with 7.4.0 (c048cede,
-     *                      https://forge.typo3.org/issues/68186)
-     * @param AjaxRequestHandler $ajaxObj Object of type AjaxRequestHandler
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
      *
-     * @return void
+     * @return ResponseInterface
      */
-    public function whitelistAction($params = array(), AjaxRequestHandler &$ajaxObj = null);
+    public function whitelistAction(ServerRequestInterface $request, ResponseInterface $response);
 
     /**
      * Deletes an entry from the sitemap. Entry will reappear as soon as it's indexed again
      *
-     * @param array $params Array of parameters from the AJAX interface, currently unused (as of 6.2.14)
-     *                      becomes available starting with 7.4.0 (c048cede,
-     *                      https://forge.typo3.org/issues/68186)
-     * @param AjaxRequestHandler $ajaxObj Object of type AjaxRequestHandler
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
      *
-     * @return void
+     * @return ResponseInterface
      */
-    public function deleteAction($params = array(), AjaxRequestHandler &$ajaxObj = null);
+    public function deleteAction(ServerRequestInterface $request, ResponseInterface $response);
 
     /**
      * Performs delete operation for all the entries in the sitemap
      *
-     * @param array $params Array of parameters from the AJAX interface, currently unused (as of 6.2.14)
-     *                      becomes available starting with 7.4.0 (c048cede,
-     *                      https://forge.typo3.org/issues/68186)
-     * @param AjaxRequestHandler $ajaxObj Object of type AjaxRequestHandler
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
      *
-     * @return void
+     * @return ResponseInterface
      */
-    public function deleteAllAction($params = array(), AjaxRequestHandler &$ajaxObj = null);
-
-
-
+    public function deleteAllAction(ServerRequestInterface $request, ResponseInterface $response);
 }

--- a/Classes/Utility/ExtensionManagementUtility.php
+++ b/Classes/Utility/ExtensionManagementUtility.php
@@ -42,9 +42,12 @@ class ExtensionManagementUtility
      *
      * @param string $qualifiedClassName
      * @param string $ajaxPrefix
+     *
+     * @return array
      */
-    public static function registerAjaxClass($qualifiedClassName, $ajaxPrefix = '')
+    public static function getAjaxRoutesOfClass($qualifiedClassName, $ajaxPrefix = '')
     {
+        $ajaxRoutes = array();
         if (!empty($ajaxPrefix)) {
             $ajaxPrefix = $ajaxPrefix . self::AJAX_METHOD_DELIMITER;
         }
@@ -55,22 +58,29 @@ class ExtensionManagementUtility
             $methodName = $method->getName();
             if (self::isAjaxMethod($methodName)) {
                 $ajaxMethodName = self::extractAjaxMethod($methodName);
-                Typo3ExtensionManagementUtility::registerAjaxHandler(
-                    $ajaxPrefix . $ajaxMethodName,
-                    $qualifiedClassName . '->' . $methodName
+                $ajaxRoutes[$ajaxPrefix . $ajaxMethodName] = array(
+                    'path' => $ajaxPrefix . $ajaxMethodName,
+                    'target' => $qualifiedClassName . '::' . $ajaxMethodName . self::AJAX_METHOD_NAME_SUFFIX, //AjaxID
                 );
             }
         }
+        return $ajaxRoutes;
     }
+
+
 
     /**
      * @param array $qualifiedClassNames
+     *
+     * @return array Ajax routes to be registered
      */
-    public static function registerAjaxClasses(array $qualifiedClassNames)
+    public static function registerAjaxRoutes(array $qualifiedClassNames)
     {
+        $ajaxRoutes = array();
         foreach ($qualifiedClassNames as $ajaxPrefix => $qualifiedClassName) {
-            self::registerAjaxClass($qualifiedClassName, $ajaxPrefix);
+            $ajaxRoutes = array_merge($ajaxRoutes, self::getAjaxRoutesOfClass($qualifiedClassName, $ajaxPrefix));
         }
+        return $ajaxRoutes;
     }
 
     /**

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -1,0 +1,14 @@
+<?php
+
+// ############################################################################
+// REGISTER AJAX CONTROLLERS
+// ############################################################################
+
+return array_merge(
+    \Metaseo\Metaseo\Utility\ExtensionManagementUtility::registerAjaxRoutes(
+        \Metaseo\Metaseo\Controller\Ajax\AbstractPageSeoController::getBackendAjaxClassNames()
+    ),
+    \Metaseo\Metaseo\Utility\ExtensionManagementUtility::registerAjaxRoutes(
+        \Metaseo\Metaseo\Controller\Ajax\SitemapController::getBackendAjaxClassNames()
+    )
+);

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -97,17 +97,6 @@ if (TYPO3_MODE == 'BE') {
             'labels' => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/ModuleSitemap/locallang.xlf',
         )
     );
-
-    // ############################################################################
-    // REGISTER AJAX CONTROLLERS
-    // ############################################################################
-    // AJAX
-    \Metaseo\Metaseo\Utility\ExtensionManagementUtility::registerAjaxClasses(
-        \Metaseo\Metaseo\Controller\Ajax\AbstractPageSeoController::getBackendAjaxClassNames()
-    );
-    \Metaseo\Metaseo\Utility\ExtensionManagementUtility::registerAjaxClasses(
-        \Metaseo\Metaseo\Controller\Ajax\SitemapController::getBackendAjaxClassNames()
-    );
 }
 
 // ############################################################################


### PR DESCRIPTION
* not using deprecated BackendUtility::getAjaxUrl() any more
* now using ResponseInterface
* ServerRequestInterface is still unused, added it just for
  the correct function signature (preliminary for issue #209)
* Adopted interfaces accordingly
* Adopted exception handling accordingly

Fixes #396
Fixes #397