### PR TITLE
Feature/8lts Fix link meta tags links

### DIFF
--- a/Classes/Page/Part/MetatagPart.php
+++ b/Classes/Page/Part/MetatagPart.php
@@ -1253,19 +1253,19 @@ class MetatagPart extends AbstractPart
         // to prevent linking to other domains
         // see https://github.com/mblaschke/TYPO3-metaseo/issues/5
         if (!$currentIsRootpage) {
-            $startPage    = $GLOBALS['TSFE']->cObj->HMENU($this->tsSetupSeo['sectionLinks.']['start.']);
+            $startPage = $GLOBALS['TSFE']->cObj->cObjGetSingle('HMENU', $this->tsSetupSeo['sectionLinks.']['start.']);
             $startPageUrl = null;
             if (!empty($startPage)) {
                 $startPageUrl = $this->generateLink($startPage);
             }
 
-            $prevPage    = $GLOBALS['TSFE']->cObj->HMENU($this->tsSetupSeo['sectionLinks.']['prev.']);
+            $prevPage =  $GLOBALS['TSFE']->cObj->cObjGetSingle('HMENU', $this->tsSetupSeo['sectionLinks.']['prev.']);
             $prevPageUrl = null;
             if (!empty($prevPage)) {
                 $prevPageUrl = $this->generateLink($prevPage);
             }
 
-            $nextPage    = $GLOBALS['TSFE']->cObj->HMENU($this->tsSetupSeo['sectionLinks.']['next.']);
+            $nextPage =  $GLOBALS['TSFE']->cObj->cObjGetSingle('HMENU', $this->tsSetupSeo['sectionLinks.']['next.']);
             $nextPageUrl = null;
             if (!empty($nextPage)) {
                 $nextPageUrl = $this->generateLink($nextPage);

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -195,6 +195,7 @@ plugin.metaseo {
                 special {
                     items = first
                     first.fields.title =
+                    first.fields.nav_title =
                 }
 
                 1 = TMENU
@@ -211,6 +212,7 @@ plugin.metaseo {
                 special {
                     items = prev
                     prev.fields.title =
+                    prev.fields.nav_title =
                 }
 
                 1 = TMENU
@@ -227,6 +229,7 @@ plugin.metaseo {
                 special {
                     items = next
                     next.fields.title =
+                    next.fields.nav_title =
                 }
 
                 1 = TMENU


### PR DESCRIPTION
This pull request fixes two things related to link meta tags:

- Call to undefined method TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::HMENU() because the method was removed in 8.0 (see https://forge.typo3.org/projects/typo3cms-core/repository/revisions/aa0013f09ba528c6ac2b51d6ca78ca2c005d552b/entry/typo3/sysext/core/Documentation/Changelog/master/Breaking-72361-RemovedDeprecatedContentObjectWrappers.rst)

- prev/next was always set to the root page when nav_title was used. Fix that by also resetting it in the HMENU TypoScript
