### PR TITLE
[BUGFIX] linkGeneration always set to the root page when using nav_title

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -195,6 +195,7 @@ plugin.metaseo {
                 special {
                     items = first
                     first.fields.title =
+                    first.fields.nav_title =
                 }
 
                 1 = TMENU
@@ -211,6 +212,7 @@ plugin.metaseo {
                 special {
                     items = prev
                     prev.fields.title =
+                    prev.fields.nav_title =
                 }
 
                 1 = TMENU
@@ -227,6 +229,7 @@ plugin.metaseo {
                 special {
                     items = next
                     next.fields.title =
+                    next.fields.nav_title =
                 }
 
                 1 = TMENU


### PR DESCRIPTION
in setup.txt,

* reset the nav_title in section links or link meta to fix meta tags
  pointing always to the root page when nav_title is set

Fixes #443