### PR TITLE
[FEATURE] 8LTS: transitioning from disabled pages.url_scheme

### DIFF
--- a/Classes/Controller/Ajax/PageSeo/UrlController.php
+++ b/Classes/Controller/Ajax/PageSeo/UrlController.php
@@ -41,11 +41,13 @@ class UrlController extends AbstractPageSeoSimController
      */
     protected function initFieldList()
     {
-        $fieldList = array(
-            'title',
-            'url_scheme',
-            'alias',
-        );
+        $fieldList = array();
+
+        $fieldList[] = 'title';
+        if (ExtensionManagementUtility::isLoaded('compatibility7')) {
+            $fieldList[] = 'url_scheme';
+        }
+        $fieldList[] = 'alias';
         if (ExtensionManagementUtility::isLoaded('realurl')) {
             $fieldList[] = 'tx_realurl_pathsegment';
             $fieldList[] = 'tx_realurl_pathoverride';

--- a/Classes/Controller/BackendPageSeoController.php
+++ b/Classes/Controller/BackendPageSeoController.php
@@ -194,6 +194,7 @@ class BackendPageSeoController extends AbstractStandardModule
         // ############################
 
         $realUrlAvailable = ExtensionManagementUtility::isLoaded('realurl');
+        $urlSchemeAvailable = ExtensionManagementUtility::isLoaded('compatibility7');
 
         $ajaxController = AbstractPageSeoController::AJAX_PREFIX . $listType;
 
@@ -215,6 +216,7 @@ class BackendPageSeoController extends AbstractStandardModule
             'listType'         => $listType,
             'criteriaFulltext' => '',
             'realurlAvailable' => $realUrlAvailable,
+            'urlSchemeAvailable' => $urlSchemeAvailable,
             'sprite'           => array(
                 'edit'   => $iconFactory->getIcon('actions-document-open', Icon::SIZE_SMALL)->render(),
                 'info'   => $iconFactory->getIcon('actions-document-info', Icon::SIZE_SMALL)->render(),

--- a/Classes/Page/Part/MetatagPart.php
+++ b/Classes/Page/Part/MetatagPart.php
@@ -1331,6 +1331,7 @@ class MetatagPart extends AbstractPart
      */
     protected function generateCanonicalUrl()
     {
+        $extCompat7 = ExtensionManagementUtility::isLoaded('compatibility7');
         //User has specified a canonical URL in the page properties
         if (!empty($this->pageRecord['tx_metaseo_canonicalurl'])) {
             return $this->generateLink($this->pageRecord['tx_metaseo_canonicalurl']);
@@ -1344,7 +1345,7 @@ class MetatagPart extends AbstractPart
             if (!empty($clUrl) && isset($clLinkConf) && isset($clDisableMpMode)) {
                 $url = $this->generateLink($clUrl, $clLinkConf, $clDisableMpMode);
                 return $this->setFallbackProtocol(
-                    $this->pageRecord['url_scheme'], //page properties protocol selection
+                    $extCompat7 ? $this->pageRecord['url_scheme'] : null, //page properties protocol selection
                     $this->tsSetupSeo['canonicalUrl.']['fallbackProtocol'],
                     $url
                 );

--- a/Resources/Public/Backend/JavaScript/MetaSeo.overview.js
+++ b/Resources/Public/Backend/JavaScript/MetaSeo.overview.js
@@ -448,9 +448,14 @@ MetaSeo.overview.grid = {
 
             case 'url':
                 gridDsColumns.push(
-                    {name: 'alias', type: 'string'},
-                    {name: 'url_scheme', type: 'string'}
+                    {name: 'alias', type: 'string'}
                 );
+
+                if (MetaSeo.overview.conf.urlSchemeAvailable) {
+                    gridDsColumns.push(
+                        {name: 'url_scheme', type: 'string'}
+                    );
+                }
 
                 if (MetaSeo.overview.conf.realurlAvailable) {
                     gridDsColumns.push(
@@ -810,35 +815,39 @@ MetaSeo.overview.grid = {
                 };
 
 
+                if (MetaSeo.overview.conf.urlSchemeAvailable) {
+                    columnModel.push({
+                        id: 'url_scheme',
+                        header: MetaSeo.overview.conf.lang.page_url_scheme,
+                        width: 100,
+                        sortable: false,
+                        dataIndex: 'url_scheme',
+                        renderer: fieldRendererUrlScheme,
+                        metaSeoClickEdit: {
+                            xtype: 'combo',
+                            forceSelection: true,
+                            editable: false,
+                            mode: 'local',
+                            triggerAction: 'all',
+                            store: new Ext.data.ArrayStore({
+                                id: 0,
+                                fields: [
+                                    'id',
+                                    'label'
+                                ],
+                                data: [
+                                    [0, MetaSeo.overview.conf.lang.page_url_scheme_default],
+                                    [1, MetaSeo.overview.conf.lang.page_url_scheme_http],
+                                    [2, MetaSeo.overview.conf.lang.page_url_scheme_https]
+                                ]
+                            }),
+                            valueField: 'id',
+                            displayField: 'label'
+                        }
+                    });
+                }
+
                 columnModel.push({
-                    id: 'url_scheme',
-                    header: MetaSeo.overview.conf.lang.page_url_scheme,
-                    width: 100,
-                    sortable: false,
-                    dataIndex: 'url_scheme',
-                    renderer: fieldRendererUrlScheme,
-                    metaSeoClickEdit: {
-                        xtype: 'combo',
-                        forceSelection: true,
-                        editable: false,
-                        mode: 'local',
-                        triggerAction: 'all',
-                        store: new Ext.data.ArrayStore({
-                            id: 0,
-                            fields: [
-                                'id',
-                                'label'
-                            ],
-                            data: [
-                                [0, MetaSeo.overview.conf.lang.page_url_scheme_default],
-                                [1, MetaSeo.overview.conf.lang.page_url_scheme_http],
-                                [2, MetaSeo.overview.conf.lang.page_url_scheme_https]
-                            ]
-                        }),
-                        valueField: 'id',
-                        displayField: 'label'
-                    }
-                }, {
                     id: 'alias',
                     header: MetaSeo.overview.conf.lang.page_url_alias,
                     width: 200,


### PR DESCRIPTION
* disable dealing with removed attribute pages.url_scheme (in 8 LTS)
* installing extension compatibility7 gives back the old behaviour

Canonical tag: Users are highly encouraged to use the
canonicalUrl.fallbackProtocol TS variable

Fixes #411