### PR TITLE
[FEATURE] Make metaseo compatible to custom page types

### DIFF
--- a/Classes/Controller/Ajax/AbstractPageSeoController.php
+++ b/Classes/Controller/Ajax/AbstractPageSeoController.php
@@ -32,6 +32,7 @@ use Metaseo\Metaseo\Controller\Ajax\PageSeo as PageSeo;
 use Metaseo\Metaseo\DependencyInjection\Utility\HttpUtility;
 use Metaseo\Metaseo\Exception\Ajax\AjaxException;
 use TYPO3\CMS\Core\Http\AjaxRequestHandler;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 
 /**
  * TYPO3 Backend ajax module page
@@ -352,10 +353,23 @@ abstract class AbstractPageSeoController extends AbstractAjaxController implemen
             ->objectManager
             ->get('Metaseo\\Metaseo\\Dao\\PageSeoDao')
             ->setPageTreeView($this->getPageTreeView())
-            ->setDataHandler($this->getDataHandler());
+            ->setDataHandler($this->getDataHandler())
+            ->setExtensibilityOptions($this->getExtensibilityOptions());
     }
 
     /**
+     * return array
+     */
+    protected function getExtensibilityOptions()
+    {
+        $config = $this
+            ->objectManager
+            ->get('TYPO3\\CMS\\Extbase\\Configuration\\ConfigurationManager')
+            ->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
+        return $config['plugin.']['metaseo.']['extensibility.'];
+    }
+
+        /**
      * @return \TYPO3\CMS\Core\DataHandling\DataHandler
      */
     protected function getDataHandler()

--- a/Classes/Dao/PageSeoDao.php
+++ b/Classes/Dao/PageSeoDao.php
@@ -40,6 +40,12 @@ class PageSeoDao extends Dao
     protected $pageTreeView;
 
     /**
+     * Extended options set via plugin.metaseo.extensibility
+     * @var array
+     */
+    protected $extensibilityOptions;
+
+    /**
      * Return default tree
      *
      * @param   array   $page              Root page
@@ -68,8 +74,10 @@ class PageSeoDao extends Dao
         foreach ($fieldList as $field) {
             $tree->addField($field, true);
         }
+
         $tree->init(
-            'AND doktype IN (1,4) AND ' . $this->getBackendUserAuthentication()->getPagePermsClause(1)
+            'AND doktype IN (' . $this->getDocTypeList() . ') AND '
+            . $this->getBackendUserAuthentication()->getPagePermsClause(1)
         );
 
         $tree->tree[] = array(
@@ -174,6 +182,23 @@ class PageSeoDao extends Dao
         }
 
         return $list;
+    }
+
+    protected function getDocTypeList()
+    {
+        if (!isset($this->extensibilityOptions['allowedDoktypes'])
+            || empty($this->extensibilityOptions['allowedDoktypes'])
+        ) {
+            return '1,4'; //default
+        }
+
+        // validate input
+        $allowedDoktypes = explode(',', $this->extensibilityOptions['allowedDoktypes']);
+        foreach ($allowedDoktypes as &$allowedDoktype) {
+            $allowedDoktype = (int)trim($allowedDoktype);
+        }
+
+        return implode(',', $allowedDoktypes);
     }
 
     /**
@@ -320,6 +345,18 @@ class PageSeoDao extends Dao
     public function setPageTreeView($pageTreeView)
     {
         $this->pageTreeView = $pageTreeView;
+
+        return $this;
+    }
+
+    /**
+     * @param array $extensibilityOptions
+     *
+     * @return $this
+     */
+    public function setExtensibilityOptions(array $extensibilityOptions)
+    {
+        $this->extensibilityOptions = $extensibilityOptions;
 
         return $this;
     }

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -2,6 +2,7 @@
 # This are the default TS-constants for metaseo
 ##
 plugin.metaseo {
+
     # cat=plugin.metaseo.metaTags/page/01; type=string; label= Meta Description: Short description of your webpage.
     metaTags.description =
 
@@ -181,4 +182,7 @@ plugin.metaseo {
 
     # cat=plugin.metaseo.sitemap/index/01; type=boolean; label= Lastmod tag in sitemap: Include lastmod tag in sitemap
     sitemap.enableLastMod = 1
+
+    # cat=plugin.metaseo.extensibility/page/01; type=string; label= Doktypes list for backend page tree
+    extensibility.allowedDoktypes = 1,4
 }

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -25,6 +25,13 @@ page {
 # TypoScript added by extension "metaseo"
 plugin.metaseo =
 plugin.metaseo {
+
+    # extensibility options
+    extensibility =
+    extensibility {
+        allowedDoktypes = {$plugin.metaseo.extensibility.allowedDoktypes}
+    }
+
     # Page title generator
     pageTitle =
     pageTitle {

--- a/Documentation/Constants/Index.rst
+++ b/Documentation/Constants/Index.rst
@@ -293,3 +293,19 @@ Page priority depth multiplier      Page depth multiplier, see formula in page p
 
 Page priority depth modificator     Page depth modificator, see formula in page priority         1
 =================================   ==========================================================   =================
+
+Extensibility
+-------------
+=================================   ==================================================================   =================
+Constant                            Description                                                          Default
+=================================   ==================================================================   =================
+allowedDoktypes                     List of doktypes (page types) which should be displayed in the web   1,4
+                                    module tree. You can extend these types by overriding this
+                                    constant or by adding your own custom page type to the list.
+
+                                    For example:
+
+                                    `plugin.metaseo.extensibility.allowedDoktypes := addToList(91)`
+
+                                    in your own typoscript setup adds the custom page type 91 to the
+                                    list of allowed doktypes.

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -144,5 +144,6 @@ Thanks to...
 - Attila Glück
 - Simon Schaufelberger
 - Marcus Müller
+- Birger Stöckelmann
 - all other contributors and bug reporters
 - famfamfam for these cool silk icons http://www.famfamfam.com/lab/icons/silk/

--- a/Tests/Unit/Controller/Ajax/AbstractPageSeoControllerTest.php
+++ b/Tests/Unit/Controller/Ajax/AbstractPageSeoControllerTest.php
@@ -123,6 +123,10 @@ abstract class AbstractPageSeoControllerTest extends UnitTestCase
                 $this->getPageSeoDaoMock()
             ),
             array(
+                'TYPO3\\CMS\\Extbase\\Configuration\\ConfigurationManager',
+                $this->getConfigurationManagerMock()
+            ),
+            array(
                 'Metaseo\\Metaseo\\Dao\\TemplateDao',
                 $this->getTemplateDaoMock()
             ),
@@ -193,6 +197,10 @@ abstract class AbstractPageSeoControllerTest extends UnitTestCase
             ->expects($this->any())
             ->method('setPageTreeView')
             ->will($this->returnSelf());
+        $mock
+            ->expects($this->any())
+            ->method('setExtensibilityOptions')
+            ->will($this->returnSelf());
         return $mock;
     }
 
@@ -219,6 +227,31 @@ abstract class AbstractPageSeoControllerTest extends UnitTestCase
             ->expects($this->any())
             ->method('getExcludeListArray')
             ->will($this->returnValue(array()));
+        return $mock;
+    }
+
+    /**
+     * @return \TYPO3\CMS\Extbase\Configuration\ConfigurationManager
+     */
+    protected function getConfigurationManagerMock()
+    {
+        $mock = $this->getMock('TYPO3\\CMS\\Extbase\\Configuration\\ConfigurationManager');
+        $mock
+            ->expects($this->any())
+            ->method('getConfiguration')
+            ->will(
+                $this->returnValue(
+                    array(
+                        'plugin.' => array(
+                            'metaseo.' => array(
+                                'extensibility.' => array(
+                                    'allowedDoktypes' => '1,4'
+                                )
+                            )
+                        )
+                    )
+                )
+            );
         return $mock;
     }
 


### PR DESCRIPTION
* defaults to doktypes 1 or 4
* allows to add more doktypes via TypoScript configuration
  variable extensibility.allowedDoktypes
* changes to PageSeoDao to use this simple configuration
  instead of the hard coded preset

Fixes #231