### PR TITLE
[FEATURE] 8LTS: Use subproperties for additionalHeaders

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -514,7 +514,17 @@ metaSeoSitemapTxt {
 
     config {
         disableAllHeaderCode = 1
-        additionalHeaders = Content-type:text/plain;charset=UTF-8 | X-Robots-Tag: noindex
+        additionalHeaders {
+            10 {
+                header = Content-type: text/plain;charset=UTF-8
+                replace = 1
+            }
+            20 {
+                header = X-Robots-Tag: noindex
+                replace = 1
+            }
+        }
+
         xhtml_cleaning = 0
 
         ## disable static documents and stuff
@@ -553,7 +563,17 @@ metaSeoSitemapXml {
 
     config {
         disableAllHeaderCode = 1
-        additionalHeaders = Content-type: application/xml;charset=UTF-8 | X-Robots-Tag: noindex
+        additionalHeaders {
+            10 {
+                header = Content-type: application/xml;charset=UTF-8
+                replace = 1
+            }
+            20 {
+                header = X-Robots-Tag: noindex
+                replace = 1
+            }
+        }
+
         xhtml_cleaning = 0
 
         ## disable static documents and stuff
@@ -587,7 +607,17 @@ metaSeoRobotsTxt {
 
     config {
         disableAllHeaderCode = 1
-        additionalHeaders = Content-type:text/plain;charset=UTF-8 | X-Robots-Tag: noindex
+        additionalHeaders {
+            10 {
+                header = Content-type: text/plain;charset=UTF-8
+                replace = 1
+            }
+            20 {
+                header = X-Robots-Tag: noindex
+                replace = 1
+            }
+        }
+
         xhtml_cleaning = 0
 
         ## disable static documents and stuff


### PR DESCRIPTION
* As of breaking change 72424, additionalHeaders must be used
  together with subproperties.

Fixes #478