### PR TITLE
Add TYPO3 8 compatible FlashMessage Rendering in update script

### DIFF
--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -132,7 +132,7 @@ class ext_update
         if ($this->clearCache) {
 
             // Init TCE
-            $TCE        = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\DataHandling\\DataHandler');
+            $TCE        = GeneralUtility::makeInstance(TYPO3\CMS\Core\DataHandling\DataHandler::class);
             $TCE->admin = 1;
             $TCE->clear_cacheCmd('all');
 
@@ -192,19 +192,19 @@ class ext_update
      */
     protected function generateOutput()
     {
-        $output = '';
-
+        $flashMessageService = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Messaging\FlashMessageService::class);
+        $messageQueue = $flashMessageService->getMessageQueueByIdentifier();
         foreach ($this->messageList as $message) {
             $flashMessage = GeneralUtility::makeInstance(
-                'TYPO3\\CMS\\Core\\Messaging\\FlashMessage',
+                FlashMessage::class,
                 $message[2],
                 $message[1],
                 $message[0]
             );
-            $output .= $flashMessage->render();
+            $messageQueue->addMessage($flashMessage);
         }
 
-        return $output;
+        return $messageQueue->renderFlashMessages();
     }
 
 


### PR DESCRIPTION
This fixes the issue, that executing the updater script in the TYPO3 8
backend results in a fatal error, because the FlashMessage handling has
been changed.