### PR TITLE
Ignore deleted entries from pages_language_overlay

### DIFF
--- a/Classes/Dao/PageSeoDao.php
+++ b/Classes/Dao/PageSeoDao.php
@@ -266,6 +266,7 @@ class PageSeoDao extends Dao
                 $query     = 'SELECT uid
                                 FROM pages_language_overlay
                                WHERE pid = ' . (int)$pid . '
+                               AND deleted = 0
                                  AND sys_language_uid = ' . (int)$sysLanguage;
                 $overlayId = DatabaseUtility::getOne($query);
 


### PR DESCRIPTION
Man kann bei page language overlay keine felder setzen wenn es ein gelösche page language overlay existiert.