### PR TITLE
#518 fix sitemap generation path in scheduler tasks

### DIFF
--- a/Classes/Scheduler/Task/SitemapTxtTask.php
+++ b/Classes/Scheduler/Task/SitemapTxtTask.php
@@ -69,7 +69,7 @@ class SitemapTxtTask extends AbstractSitemapTask
         $content   = $generator->sitemap();
 
         $fileName = sprintf($sitemapFileName, $rootPageId, $languageId);
-        $this->writeToFile(PATH_site . '/' . $this->sitemapDir . '/' . $fileName, $content);
+        $this->writeToFile(PATH_site . $this->sitemapDir . '/' . $fileName, $content);
 
         return true;
     }

--- a/Classes/Scheduler/Task/SitemapXmlTask.php
+++ b/Classes/Scheduler/Task/SitemapXmlTask.php
@@ -80,13 +80,13 @@ class SitemapXmlTask extends AbstractSitemapTask
         // Index
         $content  = $generator->sitemapIndex();
         $fileName = sprintf($sitemapIndexFileName, $rootPageId, $languageId);
-        $this->writeToFile(PATH_site . '/' . $this->sitemapDir . '/' . $fileName, $content);
+        $this->writeToFile(PATH_site . $this->sitemapDir . '/' . $fileName, $content);
 
         // Page
         for ($i = 0; $i < $pageCount; $i++) {
             $content  = $generator->sitemap($i);
             $fileName = sprintf($sitemapPageFileName, $rootPageId, $languageId, $i);
-            $this->writeToFile(PATH_site . '/' . $this->sitemapDir . '/' . $fileName, $content);
+            $this->writeToFile(PATH_site . $this->sitemapDir . '/' . $fileName, $content);
         }
 
         return true;


### PR DESCRIPTION
The path in generated with double slashes - for global variable "PATH_site" is defined to have a slash in the end. Even if this works on most systems - some system-setups have problems with that, so it should be fixed.